### PR TITLE
Fix bug in raincloud plots with first level equal to 1

### DIFF
--- a/R/commonTTest.R
+++ b/R/commonTTest.R
@@ -526,7 +526,7 @@ summarySEwithin <- function(data=NULL, measurevar, betweenvars=NULL, withinvars=
     p <- p + ggplot2::coord_flip()
   }
 
-  if (levels(grp) == 1) {
+  if (length(levels(grp)) == 1) {
     xBreaks <- NULL
     xLabels <- NULL
     if (!is.null(testValue))


### PR DESCRIPTION
Fixes a bug where the x-axis of raincloud plots disappeared when the first level of a factor was equal to 1.