### PR TITLE
add footnote symbol only on BF column instead of entire row

### DIFF
--- a/R/commonbayesianttest.R
+++ b/R/commonbayesianttest.R
@@ -470,7 +470,7 @@
   
   for (var in dependents) {
     if (!is.null(ttestResults[["errorFootnotes"]][[var]]))
-      ttestTable$addFootnote(ttestResults[["errorFootnotes"]][[var]], rowNames = var)
+      ttestTable$addFootnote(ttestResults[["errorFootnotes"]][[var]], rowNames = var, colNames = "BF")
     if (!is.null(ttestResults[["footnotes"]][[var]]))
       ttestTable$addFootnote(message = ttestResults[["footnotes"]][[var]], symbol = "", rowNames = var, colNames = "error")
   }

--- a/R/ttestbayesianindependentsamples.R
+++ b/R/ttestbayesianindependentsamples.R
@@ -67,7 +67,7 @@ TTestBayesianIndependentSamples <- function(jaspResults, dataset, options) {
     if (!isFALSE(errors[[var]])) {
 
       errorMessage <- errors[[var]]$message
-      ttestTable$addFootnote(errorMessage, rowNames = var)
+      ttestTable$addFootnote(errorMessage, rowNames = var, colNames = "BF")
       ttestResults[["status"]][var] <- "error"
       ttestResults[["errorFootnotes"]][[var]] <- errorMessage
       ttestRows[var, -1L] <- NaN # everything except the first because the length and names differ for student vs wilcoxon
@@ -98,7 +98,7 @@ TTestBayesianIndependentSamples <- function(jaspResults, dataset, options) {
           errorMessage <- .extractErrorMessage(r)
 	    		ttestResults[["status"]][[var]] <- "error"
 	    		ttestResults[["errorFootnotes"]][[var]] <- errorMessage
-	    		ttestTable$addFootnote(message = errorMessage, rowNames = var)
+	    		ttestTable$addFootnote(message = errorMessage, rowNames = var, colNames = "BF")
 
         } else {
 
@@ -146,7 +146,7 @@ TTestBayesianIndependentSamples <- function(jaspResults, dataset, options) {
             errorMessage <- .extractErrorMessage(r)
             ttestResults[["status"]][var] <- "error"
             ttestResults[["errorFootnotes"]][[var]] <- errorMessage
-            ttestTable$addFootnote(message = errorMessage, rowNames = var)
+            ttestTable$addFootnote(message = errorMessage, rowNames = var, colNames = "BF")
             
           } else {
             ttestResults[["delta"]][[var]]  <- r[["deltaSamples"]]

--- a/R/ttestbayesianonesample.R
+++ b/R/ttestbayesianonesample.R
@@ -54,7 +54,7 @@ TTestBayesianOneSample <- function(jaspResults, dataset, options, state = NULL) 
     if (!isFALSE(errors[[var]])) {
 
       errorMessage <- errors[[var]]$message
-      ttestTable$addFootnote(errorMessage, rowNames = var)
+      ttestTable$addFootnote(errorMessage, rowNames = var, colNames = "BF")
       ttestResults[["status"]][var] <- "error"
       ttestResults[["errorFootnotes"]][[var]] <- errorMessage
       ttestRows[var, c("BF", "error")] <- NaN
@@ -78,8 +78,8 @@ TTestBayesianOneSample <- function(jaspResults, dataset, options, state = NULL) 
           errorMessage <- .extractErrorMessage(r)
           ttestResults[["status"]][var] <- "error"
           ttestResults[["errorFootnotes"]][[var]] <- errorMessage
-          ttestTable$addFootnote(message = errorMessage, rowNames = var)
   
+          ttestTable$addFootnote(message = errorMessage, rowNames = var, colNames = "BF")
         } else {
   
           bf.raw <- r[["bf"]]
@@ -130,7 +130,7 @@ TTestBayesianOneSample <- function(jaspResults, dataset, options, state = NULL) 
             errorMessage <- .extractErrorMessage(r)
             ttestResults[["status"]][var] <- "error"
             ttestResults[["errorFootnotes"]][[var]] <- errorMessage
-            ttestTable$addFootnote(message = errorMessage, rowNames = var)
+            ttestTable$addFootnote(message = errorMessage, rowNames = var, colNames = "BF")
 
           } else {
             

--- a/R/ttestbayesianpairedsamples.R
+++ b/R/ttestbayesianpairedsamples.R
@@ -60,7 +60,7 @@ TTestBayesianPairedSamples <- function(jaspResults, dataset, options) {
       if (!isFALSE(errors[[var]])) {
 
         errorMessage <- errors[[var]]$message
-        ttestTable$addFootnote(errorMessage, rowNames = var)
+        ttestTable$addFootnote(errorMessage, rowNames = var, colNames = "BF")
         ttestResults[["status"]][var] <- "error"
         ttestResults[["errorFootnotes"]][[var]] <- errorMessage
         ttestRows[var, c("BF", "error")] <- NaN
@@ -88,7 +88,7 @@ TTestBayesianPairedSamples <- function(jaspResults, dataset, options) {
             errorMessage <- .extractErrorMessage(r)
             ttestResults[["status"]][var] <- "error"
             ttestResults[["errorFootnotes"]][[var]] <- errorMessage
-            ttestTable$addFootnote(message = errorMessage, rowNames = var)
+            ttestTable$addFootnote(message = errorMessage, rowNames = var, colNames = "BF")
   
           } else {
   
@@ -138,7 +138,7 @@ TTestBayesianPairedSamples <- function(jaspResults, dataset, options) {
               errorMessage <- .extractErrorMessage(r)
               ttestResults[["status"]][var] <- "error"
               ttestResults[["errorFootnotes"]][[var]] <- errorMessage
-              ttestTable$addFootnote(message = errorMessage, rowNames = var)
+              ttestTable$addFootnote(message = errorMessage, rowNames = var, colNames = "BF")
               
             } else {
               


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1244

the footnote is now only shown on the BF column, for all variable related errors:

![image](https://user-images.githubusercontent.com/21319932/119002468-31aed200-b98d-11eb-9003-0b8b17e941df.png)
