### PR TITLE
Never compute robustness plots and sequential analysis for the wilcoxon

### DIFF
--- a/R/commonbayesianttest.R
+++ b/R/commonbayesianttest.R
@@ -852,6 +852,11 @@
     )
   }
 
+  # the plots below are only available for the Student's T test. returning early avoids computing
+  # the plots below when e.g., first checking Sequential analysis and then switching to Wilcoxon.
+  if (options[["testStatistic"]] == "Wilcoxon")
+    return()
+
   if (options[["plotBayesFactorRobustness"]] && options[["effectSizeStandardized"]] == "default") {
     .ttestBayesianPlotRobustness(
       collection             = inferentialPlotsCollection,


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1292

Adds an early return after the prior and posterior plots, so the remaining plots (robustness plots & sequential) are never computed.