### PR TITLE
Fix error messages for raincloud plots

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -20,6 +20,7 @@ jobs:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       R_REMOTES_UPGRADE: never
       VDIFFR_RUN_TESTS: true
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v2

--- a/R/commonbayesianttest.R
+++ b/R/commonbayesianttest.R
@@ -2202,7 +2202,7 @@
       errors <- .hasErrors(dataset, 
                        message = 'short', 
                        type = c('variance', 'infinity'),
-                       all.target = variable)
+                       all.target = pair)
       if(!isFALSE(errors)) {
         descriptivesPlotRainCloud$setError(errors$message)
         next
@@ -2241,7 +2241,7 @@
     errors <- .hasErrors(dataset, 
                        message = 'short', 
                        type = c('variance', 'infinity'),
-                       all.target = variable)
+                       all.target = pair)
     if(!isFALSE(errors)) {
       descriptivesPlotRainCloud$setError(errors$message)
       next

--- a/R/commonbayesianttest.R
+++ b/R/commonbayesianttest.R
@@ -2155,7 +2155,7 @@
                        type = c('observations', 'variance', 'infinity'),
                        all.target = variable,
                        observations.amount = c('< 2'))
-      if(!identical(errors, FALSE)) {
+      if(!isFALSE(errors)) {
         descriptivesPlotRainCloud$setError(errors$message)
         next
       }
@@ -2181,7 +2181,7 @@
                        all.target = variable,
                        observations.amount = c('< 2'),
                        observations.grouping = groups)
-      if(!identical(errors, FALSE)) {
+      if(!isFALSE(errors)) {
         descriptivesPlotRainCloud$setError(errors$message)
         next
       }
@@ -2203,7 +2203,7 @@
                        message = 'short', 
                        type = c('variance', 'infinity'),
                        all.target = variable)
-      if(!identical(errors, FALSE)) {
+      if(!isFALSE(errors)) {
         descriptivesPlotRainCloud$setError(errors$message)
         next
       }
@@ -2242,7 +2242,7 @@
                        message = 'short', 
                        type = c('variance', 'infinity'),
                        all.target = variable)
-    if(!identical(errors, FALSE)) {
+    if(!isFALSE(errors)) {
       descriptivesPlotRainCloud$setError(errors$message)
       next
     }

--- a/R/commonbayesianttest.R
+++ b/R/commonbayesianttest.R
@@ -2143,6 +2143,7 @@
   subcontainer$dependOn(c("descriptivesPlotsRainCloud", "descriptivesPlotsRainCloudHorizontalDisplay"))
   subcontainer$position <- 6
   horiz <- options$descriptivesPlotsRainCloudHorizontalDisplay
+  errors <- .ttestBayesianGetErrorsPerVariable(dataset, options, analysis)
   if (analysis == "one-sample") {
     for(variable in options$variables) {
       if(!is.null(subcontainer[[variable]]))
@@ -2150,13 +2151,8 @@
       descriptivesPlotRainCloud <- createJaspPlot(title = variable, width = 480, height = 320)
       descriptivesPlotRainCloud$dependOn(optionContainsValue = list(variables = variable))
       subcontainer[[variable]] <- descriptivesPlotRainCloud
-      errors <- .hasErrors(dataset, 
-                       message = 'short', 
-                       type = c('observations', 'variance', 'infinity'),
-                       all.target = variable,
-                       observations.amount = c('< 2'))
-      if(!isFALSE(errors)) {
-        descriptivesPlotRainCloud$setError(errors$message)
+      if(!isFALSE(errors[[variable]])) {
+        descriptivesPlotRainCloud$setError(errors[[variable]]$message)
         next
       }
       groups  <- rep("1", nrow(dataset))
@@ -2175,14 +2171,8 @@
       descriptivesPlotRainCloud <- createJaspPlot(title = variable, width = 480, height = 320)
       descriptivesPlotRainCloud$dependOn(optionContainsValue = list(variables = variable))
       subcontainer[[variable]] <- descriptivesPlotRainCloud
-      errors <- .hasErrors(dataset, 
-                       message = 'short', 
-                       type = c('observations', 'variance', 'infinity'),
-                       all.target = variable,
-                       observations.amount = c('< 2'),
-                       observations.grouping = groups)
-      if(!isFALSE(errors)) {
-        descriptivesPlotRainCloud$setError(errors$message)
+      if(!isFALSE(errors[[variable]])) {
+        descriptivesPlotRainCloud$setError(errors[[variable]]$message)
         next
       }
       p <- try(.descriptivesPlotsRainCloudFill(dataset, variable, groups, variable, groups, addLines = FALSE, horiz, NULL))
@@ -2199,12 +2189,8 @@
       descriptivesPlotRainCloud <- createJaspPlot(title = title, width = 480, height = 320)
       descriptivesPlotRainCloud$dependOn(optionContainsValue = list(pairs = pair))
       subcontainer[[title]] <- descriptivesPlotRainCloud
-      errors <- .hasErrors(dataset, 
-                       message = 'short', 
-                       type = c('variance', 'infinity'),
-                       all.target = pair)
-      if(!isFALSE(errors)) {
-        descriptivesPlotRainCloud$setError(errors$message)
+      if(!isFALSE(errors[[title]])) {
+        descriptivesPlotRainCloud$setError(errors[[title]]$message)
         next
       }
       groups  <- rep(pair, each = nrow(dataset))
@@ -2231,19 +2217,16 @@
   subcontainer$dependOn(c("descriptivesPlotsRainCloudDifference", "descriptivesPlotsRainCloudDifferenceHorizontalDisplay"))
   subcontainer$position <- 7
   horiz <- options$descriptivesPlotsRainCloudDifferenceHorizontalDisplay
+  errors <- .ttestBayesianGetErrorsPerVariable(dataset, options, analysis)
   for(pair in options$pairs) {
     title <- paste(pair, collapse = " - ")
-    if(!is.null(subcontainer[[title]]) || any(unlist(pair) == ""))
+    if(!is.null(subcontainer[[title]]))
       next
     descriptivesPlotRainCloudDifference <- createJaspPlot(title = title, width = 480, height = 320)
     descriptivesPlotRainCloudDifference$dependOn(optionContainsValue = list(pairs = pair))
     subcontainer[[title]] <- descriptivesPlotRainCloudDifference
-    errors <- .hasErrors(dataset, 
-                       message = 'short', 
-                       type = c('variance', 'infinity'),
-                       all.target = pair)
-    if(!isFALSE(errors)) {
-      descriptivesPlotRainCloud$setError(errors$message)
+    if(!isFALSE(errors[[title]])) {
+      descriptivesPlotRainCloudDifference$setError(errors[[title]]$message)
       next
     }
     groups    <- rep("1", nrow(dataset))

--- a/R/commonbayesianttest.R
+++ b/R/commonbayesianttest.R
@@ -2150,6 +2150,15 @@
       descriptivesPlotRainCloud <- createJaspPlot(title = variable, width = 480, height = 320)
       descriptivesPlotRainCloud$dependOn(optionContainsValue = list(variables = variable))
       subcontainer[[variable]] <- descriptivesPlotRainCloud
+      errors <- .hasErrors(dataset, 
+                       message = 'short', 
+                       type = c('observations', 'variance', 'infinity'),
+                       all.target = variable,
+                       observations.amount = c('< 2'))
+      if(!identical(errors, FALSE)) {
+        descriptivesPlotRainCloud$setError(errors$message)
+        next
+      }
       groups  <- rep("1", nrow(dataset))
       subData <- data.frame(dependent = dataset[, .v(variable)], groups = groups)
       p <- try(.descriptivesPlotsRainCloudFill(subData, "dependent", "groups", variable, NULL, addLines = FALSE, horiz, options$testValue))
@@ -2162,10 +2171,21 @@
     for(variable in options$variables) {
       if(!is.null(subcontainer[[variable]]))
         next
+      groups <- options$groupingVariable
       descriptivesPlotRainCloud <- createJaspPlot(title = variable, width = 480, height = 320)
       descriptivesPlotRainCloud$dependOn(optionContainsValue = list(variables = variable))
       subcontainer[[variable]] <- descriptivesPlotRainCloud
-      p <- try(.descriptivesPlotsRainCloudFill(dataset, variable, options$groupingVariable, variable, options$groupingVariable, addLines = FALSE, horiz, NULL))
+      errors <- .hasErrors(dataset, 
+                       message = 'short', 
+                       type = c('observations', 'variance', 'infinity'),
+                       all.target = variable,
+                       observations.amount = c('< 2'),
+                       observations.grouping = groups)
+      if(!identical(errors, FALSE)) {
+        descriptivesPlotRainCloud$setError(errors$message)
+        next
+      }
+      p <- try(.descriptivesPlotsRainCloudFill(dataset, variable, groups, variable, groups, addLines = FALSE, horiz, NULL))
       if(isTryError(p))
         descriptivesPlotRainCloud$setError(.extractErrorMessage(p))
       else
@@ -2179,6 +2199,14 @@
       descriptivesPlotRainCloud <- createJaspPlot(title = title, width = 480, height = 320)
       descriptivesPlotRainCloud$dependOn(optionContainsValue = list(pairs = pair))
       subcontainer[[title]] <- descriptivesPlotRainCloud
+      errors <- .hasErrors(dataset, 
+                       message = 'short', 
+                       type = c('variance', 'infinity'),
+                       all.target = variable)
+      if(!identical(errors, FALSE)) {
+        descriptivesPlotRainCloud$setError(errors$message)
+        next
+      }
       groups  <- rep(pair, each = nrow(dataset))
       subData <- data.frame(dependent = unlist(dataset[, .v(pair)]), groups = groups)
       p <- try(.descriptivesPlotsRainCloudFill(subData, "dependent", "groups", "", "", addLines = TRUE, horiz = FALSE, NULL))
@@ -2210,6 +2238,14 @@
     descriptivesPlotRainCloudDifference <- createJaspPlot(title = title, width = 480, height = 320)
     descriptivesPlotRainCloudDifference$dependOn(optionContainsValue = list(pairs = pair))
     subcontainer[[title]] <- descriptivesPlotRainCloudDifference
+    errors <- .hasErrors(dataset, 
+                       message = 'short', 
+                       type = c('variance', 'infinity'),
+                       all.target = variable)
+    if(!identical(errors, FALSE)) {
+      descriptivesPlotRainCloud$setError(errors$message)
+      next
+    }
     groups    <- rep("1", nrow(dataset))
     dependent <- dataset[, pair[[1]]] - dataset[, pair[[2]]]
     subData   <- data.frame(dependent = dependent, groups = groups)

--- a/R/ttestindependentsamples.R
+++ b/R/ttestindependentsamples.R
@@ -629,6 +629,7 @@ ttestIndependentMainTableRow <- function(variable, dataset, test, testStat, effS
   subcontainer <- container[["plotsRainCloud"]]
   subcontainer$position <- 6
   horiz <- options$descriptivesPlotsRainCloudHorizontalDisplay
+  groups <- options$groupingVariable
   for(variable in options$variables) {
     if(!is.null(subcontainer[[variable]]))
       next
@@ -636,7 +637,17 @@ ttestIndependentMainTableRow <- function(variable, dataset, test, testStat, effS
     descriptivesPlotRainCloud$dependOn(optionContainsValue = list(variables = variable))
     subcontainer[[variable]] <- descriptivesPlotRainCloud
     if(ready){
-      p <- try(.descriptivesPlotsRainCloudFill(dataset, variable, options$groupingVariable, variable, options$groupingVariable, addLines = FALSE, horiz, NULL))
+      errors <- .hasErrors(dataset, 
+                       message = 'short', 
+                       type = c('observations', 'variance', 'infinity'),
+                       all.target = variable,
+                       observations.amount = c('< 2'),
+                       observations.grouping = groups)
+      if(!identical(errors, FALSE)) {
+        descriptivesPlotRainCloud$setError(errors$message)
+        next
+      }
+      p <- try(.descriptivesPlotsRainCloudFill(dataset, variable, groups, variable, groups, addLines = FALSE, horiz, NULL))
       if(isTryError(p))
         descriptivesPlotRainCloud$setError(.extractErrorMessage(p))
       else

--- a/R/ttestindependentsamples.R
+++ b/R/ttestindependentsamples.R
@@ -629,22 +629,17 @@ ttestIndependentMainTableRow <- function(variable, dataset, test, testStat, effS
   subcontainer <- container[["plotsRainCloud"]]
   subcontainer$position <- 6
   horiz <- options$descriptivesPlotsRainCloudHorizontalDisplay
-  groups <- options$groupingVariable
-  for(variable in options$variables) {
-    if(!is.null(subcontainer[[variable]]))
-      next
-    descriptivesPlotRainCloud <- createJaspPlot(title = variable, width = 480, height = 320)
-    descriptivesPlotRainCloud$dependOn(optionContainsValue = list(variables = variable))
-    subcontainer[[variable]] <- descriptivesPlotRainCloud
-    if(ready){
-      errors <- .hasErrors(dataset, 
-                       message = 'short', 
-                       type = c('observations', 'variance', 'infinity'),
-                       all.target = variable,
-                       observations.amount = c('< 2'),
-                       observations.grouping = groups)
-      if(!isFALSE(errors)) {
-        descriptivesPlotRainCloud$setError(errors$message)
+  if(ready){
+    groups <- options$groupingVariable
+    errors <- .ttestBayesianGetErrorsPerVariable(dataset, options, "independent")
+    for(variable in options$variables) {
+      if(!is.null(subcontainer[[variable]]))
+        next
+      descriptivesPlotRainCloud <- createJaspPlot(title = variable, width = 480, height = 320)
+      descriptivesPlotRainCloud$dependOn(optionContainsValue = list(variables = variable))
+      subcontainer[[variable]] <- descriptivesPlotRainCloud
+      if(!isFALSE(errors[[variable]])) {
+        descriptivesPlotRainCloud$setError(errors[[variable]]$message)
         next
       }
       p <- try(.descriptivesPlotsRainCloudFill(dataset, variable, groups, variable, groups, addLines = FALSE, horiz, NULL))

--- a/R/ttestindependentsamples.R
+++ b/R/ttestindependentsamples.R
@@ -643,7 +643,7 @@ ttestIndependentMainTableRow <- function(variable, dataset, test, testStat, effS
                        all.target = variable,
                        observations.amount = c('< 2'),
                        observations.grouping = groups)
-      if(!identical(errors, FALSE)) {
+      if(!isFALSE(errors)) {
         descriptivesPlotRainCloud$setError(errors$message)
         next
       }

--- a/R/ttestonesample.R
+++ b/R/ttestonesample.R
@@ -437,24 +437,20 @@ TTestOneSample <- function(jaspResults, dataset = NULL, options, ...) {
   subcontainer <- container[["plotsRainCloud"]]
   subcontainer$position <- 6
   horiz <- options$descriptivesPlotsRainCloudHorizontalDisplay
-  for(variable in options$variables) {
-    if(!is.null(subcontainer[[variable]]))
-      next
-    descriptivesPlotRainCloud <- createJaspPlot(title = variable, width = 480, height = 320)
-    descriptivesPlotRainCloud$dependOn(optionContainsValue = list(variables = variable))
-    subcontainer[[variable]] <- descriptivesPlotRainCloud
-    groups  <- rep("1", nrow(dataset))
-    subData <- data.frame(dependent = dataset[, .v(variable)], groups = groups)
-    if(ready){
-      errors <- .hasErrors(dataset, 
-                       message = 'short', 
-                       type = c('observations', 'variance', 'infinity'),
-                       all.target = variable,
-                       observations.amount = c('< 2'))
-      if(!isFALSE(errors)) {
-        descriptivesPlotRainCloud$setError(errors$message)
+  if(ready){
+    errors <- .ttestBayesianGetErrorsPerVariable(dataset, options, "one-sample")
+    for(variable in options$variables) {
+      if(!is.null(subcontainer[[variable]]))
         next
+      descriptivesPlotRainCloud <- createJaspPlot(title = variable, width = 480, height = 320)
+      descriptivesPlotRainCloud$dependOn(optionContainsValue = list(variables = variable))
+      subcontainer[[variable]] <- descriptivesPlotRainCloud
+      if(!isFALSE(errors[[variable]])) {
+          descriptivesPlotRainCloud$setError(errors[[variable]]$message)
+          next
       }
+      groups  <- rep("1", nrow(dataset))
+      subData <- data.frame(dependent = dataset[, .v(variable)], groups = groups)
       p <- try(.descriptivesPlotsRainCloudFill(subData, "dependent", "groups", variable, NULL, addLines = FALSE, horiz, options$testValue))
       if(isTryError(p))
         descriptivesPlotRainCloud$setError(.extractErrorMessage(p))

--- a/R/ttestonesample.R
+++ b/R/ttestonesample.R
@@ -365,7 +365,7 @@ TTestOneSample <- function(jaspResults, dataset = NULL, options, ...) {
   container <- jaspResults[["ttestDescriptives"]]
   container[["plots"]] <- createJaspContainer(gettext("Descriptives Plots"))
   subcontainer <- container[["plots"]]
-  container$position <- 5
+  subcontainer$position <- 5
   for(variable in options$variables) {
     if(!is.null(subcontainer[[variable]]))
       next
@@ -446,6 +446,15 @@ TTestOneSample <- function(jaspResults, dataset = NULL, options, ...) {
     groups  <- rep("1", nrow(dataset))
     subData <- data.frame(dependent = dataset[, .v(variable)], groups = groups)
     if(ready){
+      errors <- .hasErrors(dataset, 
+                       message = 'short', 
+                       type = c('observations', 'variance', 'infinity'),
+                       all.target = variable,
+                       observations.amount = c('< 2'))
+      if(!identical(errors, FALSE)) {
+        descriptivesPlotRainCloud$setError(errors$message)
+        next
+      }
       p <- try(.descriptivesPlotsRainCloudFill(subData, "dependent", "groups", variable, NULL, addLines = FALSE, horiz, options$testValue))
       if(isTryError(p))
         descriptivesPlotRainCloud$setError(.extractErrorMessage(p))

--- a/R/ttestonesample.R
+++ b/R/ttestonesample.R
@@ -451,7 +451,7 @@ TTestOneSample <- function(jaspResults, dataset = NULL, options, ...) {
                        type = c('observations', 'variance', 'infinity'),
                        all.target = variable,
                        observations.amount = c('< 2'))
-      if(!identical(errors, FALSE)) {
+      if(!isFALSE(errors)) {
         descriptivesPlotRainCloud$setError(errors$message)
         next
       }

--- a/R/ttestpairedsamples.R
+++ b/R/ttestpairedsamples.R
@@ -481,7 +481,7 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
                        message = 'short', 
                        type = c('variance', 'infinity'),
                        all.target = pair)
-      if(!identical(errors, FALSE)) {
+      if(!isFALSE(errors)) {
         descriptivesPlotRainCloud$setError(errors$message)
         next
       }
@@ -519,7 +519,7 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
                        message = 'short', 
                        type = c('variance', 'infinity'),
                        all.target = pair)
-      if(!identical(errors, FALSE)) {
+      if(!isFALSE(errors)) {
         descriptivesPlotRainCloud$setError(errors$message)
         next
       }

--- a/R/ttestpairedsamples.R
+++ b/R/ttestpairedsamples.R
@@ -477,6 +477,14 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
     groups  <- rep(pair, each = nrow(dataset))
     subData <- data.frame(dependent = unlist(dataset[, pair]), groups = groups)
     if(ready){
+      errors <- .hasErrors(dataset, 
+                       message = 'short', 
+                       type = c('variance', 'infinity'),
+                       all.target = pair)
+      if(!identical(errors, FALSE)) {
+        descriptivesPlotRainCloud$setError(errors$message)
+        next
+      }
       p <- try(.descriptivesPlotsRainCloudFill(subData, "dependent", "groups", "", "", addLines = TRUE, horiz = FALSE, NULL))
       if(isTryError(p))
         descriptivesPlotRainCloud$setError(.extractErrorMessage(p))
@@ -507,6 +515,14 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
     dependent <- dataset[, pair[[1]]] - dataset[, pair[[2]]]
     subData   <- data.frame(dependent = dependent, groups = groups)
     if(ready){
+      errors <- .hasErrors(dataset, 
+                       message = 'short', 
+                       type = c('variance', 'infinity'),
+                       all.target = pair)
+      if(!identical(errors, FALSE)) {
+        descriptivesPlotRainCloud$setError(errors$message)
+        next
+      }
       p <- try(.descriptivesPlotsRainCloudFill(subData, "dependent", "groups", title, "", addLines = FALSE, horiz, NULL))
       if(isTryError(p))
         descriptivesPlotRainCloudDifference$setError(.extractErrorMessage(p))

--- a/R/ttestpairedsamples.R
+++ b/R/ttestpairedsamples.R
@@ -467,24 +467,21 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
   container[["plotsRainCloud"]] <- createJaspContainer(gettext("Raincloud Plots"))
   subcontainer <- container[["plotsRainCloud"]]
   subcontainer$position <- 6
-  for(pair in options$pairs) {
-    title <- paste(pair, collapse = " - ")
-    if(!is.null(subcontainer[[title]]) || any(unlist(pair) == ""))
-      next
-    descriptivesPlotRainCloud <- createJaspPlot(title = title, width = 480, height = 320)
-    descriptivesPlotRainCloud$dependOn(optionContainsValue = list(pairs = pair))
-    subcontainer[[title]] <- descriptivesPlotRainCloud
-    groups  <- rep(pair, each = nrow(dataset))
-    subData <- data.frame(dependent = unlist(dataset[, pair]), groups = groups)
-    if(ready){
-      errors <- .hasErrors(dataset, 
-                       message = 'short', 
-                       type = c('variance', 'infinity'),
-                       all.target = pair)
-      if(!isFALSE(errors)) {
-        descriptivesPlotRainCloud$setError(errors$message)
+  if(ready){
+    errors <- .ttestBayesianGetErrorsPerVariable(dataset, options, "paired")
+    for(pair in options$pairs) {
+      title <- paste(pair, collapse = " - ")
+      if(!is.null(subcontainer[[title]]))
+        next
+      descriptivesPlotRainCloud <- createJaspPlot(title = title, width = 480, height = 320)
+      descriptivesPlotRainCloud$dependOn(optionContainsValue = list(pairs = pair))
+      subcontainer[[title]] <- descriptivesPlotRainCloud
+      if(!isFALSE(errors[[title]])) {
+        descriptivesPlotRainCloud$setError(errors[[title]]$message)
         next
       }
+      groups  <- rep(pair, each = nrow(dataset))
+      subData <- data.frame(dependent = unlist(dataset[, pair]), groups = groups)
       p <- try(.descriptivesPlotsRainCloudFill(subData, "dependent", "groups", "", "", addLines = TRUE, horiz = FALSE, NULL))
       if(isTryError(p))
         descriptivesPlotRainCloud$setError(.extractErrorMessage(p))
@@ -504,25 +501,22 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
   subcontainer <- container[["plotsRainCloudDifference"]]
   subcontainer$position <- 7
   horiz <- options$descriptivesPlotsRainCloudDifferenceHorizontalDisplay
-  for(pair in options$pairs) {
-    title <- paste(pair, collapse = " - ")
-    if(!is.null(subcontainer[[title]]) || any(unlist(pair) == ""))
-      next
-    descriptivesPlotRainCloudDifference <- createJaspPlot(title = title, width = 480, height = 320)
-    descriptivesPlotRainCloudDifference$dependOn(optionContainsValue = list(pairs = pair))
-    subcontainer[[title]] <- descriptivesPlotRainCloudDifference
-    groups    <- rep("1", nrow(dataset))
-    dependent <- dataset[, pair[[1]]] - dataset[, pair[[2]]]
-    subData   <- data.frame(dependent = dependent, groups = groups)
-    if(ready){
-      errors <- .hasErrors(dataset, 
-                       message = 'short', 
-                       type = c('variance', 'infinity'),
-                       all.target = pair)
-      if(!isFALSE(errors)) {
-        descriptivesPlotRainCloud$setError(errors$message)
+  if(ready){
+    errors <- .ttestBayesianGetErrorsPerVariable(dataset, options, "paired")
+    for(pair in options$pairs) {
+      title <- paste(pair, collapse = " - ")
+      if(!is.null(subcontainer[[title]]))
+        next
+      descriptivesPlotRainCloudDifference <- createJaspPlot(title = title, width = 480, height = 320)
+      descriptivesPlotRainCloudDifference$dependOn(optionContainsValue = list(pairs = pair))
+      subcontainer[[title]] <- descriptivesPlotRainCloudDifference
+      if(!isFALSE(errors[[title]])) {
+        descriptivesPlotRainCloudDifference$setError(errors[[title]]$message)
         next
       }
+      groups    <- rep("1", nrow(dataset))
+      dependent <- dataset[, pair[[1]]] - dataset[, pair[[2]]]
+      subData   <- data.frame(dependent = dependent, groups = groups)
       p <- try(.descriptivesPlotsRainCloudFill(subData, "dependent", "groups", title, "", addLines = FALSE, horiz, NULL))
       if(isTryError(p))
         descriptivesPlotRainCloudDifference$setError(.extractErrorMessage(p))

--- a/inst/help/ttestbayesianindependentsamples.md
+++ b/inst/help/ttestbayesianindependentsamples.md
@@ -52,6 +52,8 @@ The independent samples t-test allows the user to estimate the effect size and t
   - Robustness check: Adds the results of the sequential analysis using the wide (scale=1) and ultrawide prior (scale=sqrt(2)).
 - Descriptives plots
   - Credible interval: Display central credible intervals. Default is 95%.
+- Raincloud plots: Displays the individual cases (colored dots), box plots, and densities for each group.
+  - Horizontal display: Changes the orientation of the raincloud plot so that the x-axis represents the dependent variable and the y-axis the grouping variable.
 
 
 ### Prior
@@ -89,6 +91,7 @@ The independent samples t-test allows the user to estimate the effect size and t
   - Robustness check: Displays the development of the Bayes factor as a function of the number of data points (n) using the wide and ultrawide prior distribution. The black circle represents the Bayes factor computed with a wide prior distribution; the white circle represents the Bayes factor computed with an ultrawide prior distribution; the gray circle represents the Bayes factor computed with the user-defined prior distribution.
 - Descriptives plots
   - Credible interval: Central credible interval. Default is 95%.
+- Raincloud plots: Displays the individual cases (colored dots), box plots, and densities for each group. The x-axis and color represent the grouping variable, and the y-axis represents the dependent variable. Within the box plots, the bold black line shows the sample median, the hinges indicate the 25th and 75th quantile, and the whiskers point to 1.5 interquartile ranges beyond the hinges. Densities are estimated using a Gaussian kernel and the bandwidth is determined with the 'nrd0' method (Silverman, 1986).
 
 
 ### References
@@ -97,6 +100,7 @@ The independent samples t-test allows the user to estimate the effect size and t
 - Jeffreys, H. (1961).  *Theory of probability (3rd ed.)*. Oxford, UK: Oxford University Press.
 - Morey, R. D., Rouder, J. N., Pratte, M. S., & Speckman, P. L. (2011). Using MCMC chain outputs to efficiently estimate Bayes factors.  *Journal of Mathematical Psychology, 55*, 368-378.
 - Rouder, J. N., Speckman, P. L., Sun, D., Morey, R. D., & Iverson, G. (2009). Bayesian t-tests for accepting and rejecting the null hypothesis.  *Psychonomic Bulletin & Review, 16*, 225-237.
+- Silverman, B. W. (1986). *Density Estimation*. London: Chapman and Hall.
 - van Doorn, J., Ly, A., Marsman, M., & Wagenmakers, E.-J. (2020). Bayesian rank-based hypothesis testing for the rank sum test, the signed rank test, and Spearman’s ρ. *Journal of Applied Statistics, 47(16)*, 2984-3006.
 
 

--- a/inst/help/ttestbayesianonesample.md
+++ b/inst/help/ttestbayesianonesample.md
@@ -59,6 +59,8 @@ Test value specified in the null hypothesis.
   - Robustness check: Adds the results of the sequential analysis using the wide (scale=1) and ultrawide prior (scale=sqrt(2)).
 - Descriptives plots
   - Credible interval: Default is 95%.
+- Raincloud plots: Displays the individual cases, box plot, and density.
+  - Horizontal display: Changes the orientation of the raincloud plot so that the x-axis represents the dependent variable.
 
 #### Missing Values
  - Exclude cases per dependent variable: In case of multiple t-tests within a single analysis, each test will be conducted using all cases with valid data for the dependent variable for the particular t-test.
@@ -94,6 +96,7 @@ Test value specified in the null hypothesis.
   - Robustness check: Displays the development of the Bayes factor as a function of the number of data points (n) using the wide and ultrawide prior distribution. The black circle represents the Bayes factor computed with a wide prior distribution; the white circle represents the Bayes factor computed with an ultrawide prior distribution; the gray circle represents the Bayes factor computed with the user-defined prior distribution.
 - Descriptives plots
   - Credible interval: Default is 95%.
+- Raincloud plots: Displays the individual cases (colored dots), box plot, and density of the sample. The y-axis represents the dependent variable. Within the box plots, the bold black line shows the sample median, the hinges indicate the 25th and 75th quantile, and the whiskers point to 1.5 interquartile ranges beyond the hinges. Densities are estimated using a Gaussian kernel and the bandwidth is determined with the 'nrd0' method (Silverman, 1986).
 
 ### References
 ---
@@ -101,6 +104,7 @@ Test value specified in the null hypothesis.
 - Jeffreys, H. (1961).  *Theory of probability (3rd ed.)*. Oxford, UK: Oxford University Press.
 - Morey, R. D., Rouder, J. N., Pratte, M. S., & Speckman, P. L. (2011). Using MCMC chain outputs to efficiently estimate Bayes factors.  *Journal of Mathematical Psychology, 55*, 368-378.
 - Rouder, J. N., Speckman, P. L., Sun, D., Morey, R. D., & Iverson, G. (2009). Bayesian t-tests for accepting and rejecting the null hypothesis.  *Psychonomic Bulletin & Review, 16*, 225-237.
+- Silverman, B. W. (1986). *Density Estimation*. London: Chapman and Hall.
 - van Doorn, J., Ly, A., Marsman, M., & Wagenmakers, E.-J. (2020). Bayesian rank-based hypothesis testing for the rank sum test, the signed rank test, and Spearman’s ρ. *Journal of Applied Statistics, 47(16)*, 2984-3006.
 
 ### R-packages

--- a/inst/help/ttestbayesianpairedsamples.md
+++ b/inst/help/ttestbayesianpairedsamples.md
@@ -42,6 +42,9 @@ The paired samples t-test allows you to estimate the effect size  and test the n
   - Robustness check: Adds the results of the sequential analysis using the wide (scale=1) and ultrawide prior (scale=sqrt(2)).
 - Descriptives plots:
   - Credible interval: Default is 95%.
+- Raincloud plots: Displays the individual cases (colored dots), box plots, and densities for each measure. 
+- Raincloud difference plots: Displays a raincloud plot of the differences between the two measures.
+  - Horizontal display: Changes the orientation of the raincloud difference plot so that the x-axis represents the dependent variable and the y-axis the difference between measures.
 
 #### Missing Values
 - Exclude cases per dependent variable: In case of multiple t-tests within a single analysis, each test will be conducted using all cases with valid data for the difference score for the particular t-test. Sample sizes may therefore vary across the multiple t-tests.
@@ -83,7 +86,8 @@ The paired samples t-test allows you to estimate the effect size  and test the n
   - Robustness check: Displays the development of the Bayes factor as a function of the number of data points (n) using the wide and ultrawide prior distribution. The black circle represents the Bayes factor computed with a wide prior distribution; the white circle represents the Bayes factor computed with an ultrawide prior distribution; the gray circle represents the Bayes factor computed with the user-defined prior distribution.
 - Descriptives plots
   - Credible interval: Default is 95%.
-
+- Raincloud plots: Displays the individual cases (colored dots), box plots, and densities for each measure. The cases from both measures are connected with individual lines. The x-axis and color represent the measures, and the y-axis represents the dependent variable. Within the box plots, the bold black line shows the sample median, the hinges indicate the 25th and 75th quantile, and the whiskers point to 1.5 interquartile ranges beyond the hinges. Densities are estimated using a Gaussian kernel and the bandwidth is determined with the 'nrd0' method (Silverman, 1986).
+- Raincloud difference plots: Displays the individual cases (colored dots), box plot, and density for the difference between the measures. The x-axis and color represent the measures, and the y-axis represents the dependent variable. Within the box plots, the bold black line shows the sample median, the hinges indicate the 25th and 75th quantile, and the whiskers point to 1.5 interquartile ranges beyond the hinges. Densities are estimated using a Gaussian kernel and the bandwidth is determined with the 'nrd0' method (Silverman, 1986).
 
 ### References
 ---
@@ -91,6 +95,7 @@ The paired samples t-test allows you to estimate the effect size  and test the n
 - Jeffreys, H. (1961).  *Theory of probability (3rd ed.)*. Oxford, UK: Oxford University Press.
 - Morey, R. D., Rouder, J. N., Pratte, M. S., & Speckman, P. L. (2011). Using MCMC chain outputs to efficiently estimate Bayes factors.  *Journal of Mathematical Psychology, 55*, 368-378.
 - Rouder, J. N., Speckman, P. L., Sun, D., Morey, R. D., & Iverson, G. (2009). Bayesian t-tests for accepting and rejecting the null hypothesis.  *Psychonomic Bulletin & Review, 16*, 225-237.
+- Silverman, B. W. (1986). *Density Estimation*. London: Chapman and Hall.
 - van Doorn, J., Ly, A., Marsman, M., & Wagenmakerss, E.-J. (2020). Bayesian rank-based hypothesis testing for the rank sum test, the signed rank test, and Spearman’s ρ. *Journal of Applied Statistics, 47(16)*, 2984-3006.
 
 ### R-packages

--- a/inst/help/ttestindependentsamples.md
+++ b/inst/help/ttestindependentsamples.md
@@ -41,6 +41,8 @@ The independent samples t-test allows the user to estimate the effect size and t
 - Descriptives: Sample size, sample mean, sample standard deviation, standard error of the mean for each group. 
 - Descriptive plots: Displays the sample means and the confidence intervals for each group. 
   - Confidence interval: Coverage of the confidence intervals in percentages. By default, the confidence interval is set to 95%. This can be changeed into the desired percentage.
+- Raincloud plots: Displays the individual cases (colored dots), box plots, and densities for each group.
+  - Horizontal display: Changes the orientation of the raincloud plot so that the x-axis represents the dependent variable and the y-axis the grouping variable.
 - Vovk-Sellke Maximum *p*-Ratio: The bound 1/(-e *p* log(*p*)) is derived from the shape of the *p*-value distribution. Under the null hypothesis (H<sub>0</sub>) it is uniform(0,1), and under the alternative (H<sub>1</sub>) it is decreasing in *p*, e.g., a beta(&#945;, 1) distribution, where 0 < &#945; < 1. The Vovk-Sellke MPR is obtained by choosing the shape &#945; of the distribution under H<sub>1</sub> such that the obtained *p*-value is *maximally diagnostic*. The value is then the ratio of the densities at point *p* under H<sub>0</sub> and H<sub>1</sub>. For example, if the two-sided *p*-value equals .05, the Vovk-Sellke MPR equals 2.46, indicating that this *p*-value is at most 2.46 times more likely to occur under H<sub>1</sub> than under H<sub>0</sub>.
 
 ### Missing Values
@@ -92,10 +94,14 @@ Test of Equality of Variances (Levene's):
 ##### Descriptive Plots 
 - Displays the sample means (black bullet), the x% confidence intervals (whiskers) for each group. The x-axis represents the grouping variable, and the y-axis the dependent variable. 
 
+##### Raincloud Plots
+- Displays the individual cases (colored dots), box plots, and densities for each group. The x-axis and color represent the grouping variable, and the y-axis represents the dependent variable. Within the box plots, the bold black line shows the sample median, the hinges indicate the 25th and 75th quantile, and the whiskers point to 1.5 interquartile ranges beyond the hinges. Densities are estimated using a Gaussian kernel and the bandwidth is determined with the 'nrd0' method (Silverman, 1986).
+
 ### References
 -------
 - Moore, D. S., McCabe, G. P., & Craig, B. A. (2012). *Introduction to the practice of statistics (7th ed.)*. New York, NY: W. H. Freeman and Company.
 - Sellke, T., Bayarri, M. J., & Berger, J. O. (2001). Calibration of *p* values for testing precise null hypotheses. *The American Statistician, 55*(1), 62-71.
+- Silverman, B. W. (1986). *Density Estimation*. London: Chapman and Hall.
 - Whitlock, M. C., & Schluter, D. (2015). *The analysis of biological data (2nd ed.)*. Greenwood Village, Colorado: Roberts and Company Publishers.
 
 ### R-packages

--- a/inst/help/ttestonesample.md
+++ b/inst/help/ttestonesample.md
@@ -36,6 +36,8 @@ The one sample t-test allows the user to estimate the effect size and test the n
 - Descriptives: Sample size, sample mean, sample standard deviation, standard error of the mean for each measure.
 - Descriptive plots: Displays the sample mean and the confidence interval.
   - Confidence interval: Coverage of the confidence intervals in percentages. By default, the confidence interval is set to 95%. This can be changed into the desired percentage.
+- Raincloud plots: Displays the individual cases, box plot, and density.
+  - Horizontal display: Changes the orientation of the raincloud plot so that the x-axis represents the dependent variable.
 - Vovk-Sellke Maximum *p*-Ratio: The bound 1/(-e *p* log(*p*)) is derived from the shape of the *p*-value distribution. Under the null hypothesis (H<sub>0</sub>) it is uniform(0,1), and under the alternative (H<sub>1</sub>) it is decreasing in *p*, e.g., a beta(&#945;, 1) distribution, where 0 < &#945; < 1. The Vovk-Sellke MPR is obtained by choosing the shape &#945; of the distribution under H<sub>1</sub> such that the obtained *p*-value is *maximally diagnostic*. The value is then the ratio of the densities at point *p* under H<sub>0</sub> and H<sub>1</sub>. For example, if the two-sided *p*-value equals .05, the Vovk-Sellke MPR equals 2.46, indicating that this *p*-value is at most 2.46 times more likely to occur under H<sub>1</sub> than under H<sub>0</sub>.
 
 #### Missing Values
@@ -78,10 +80,14 @@ Test of Normality (Shapiro-Wilk)
 #### Descriptive Plots
 - Displays the sample mean (black bullet), the % confidence interval (whiskers), and the value of the test statistic (dashed line).
 
+##### Raincloud Plots
+- Displays the individual cases (colored dots), box plot, and density of the sample. The y-axis represents the dependent variable. Within the box plots, the bold black line shows the sample median, the hinges indicate the 25th and 75th quantile, and the whiskers point to 1.5 interquartile ranges beyond the hinges. Densities are estimated using a Gaussian kernel and the bandwidth is determined with the 'nrd0' method (Silverman, 1986).
+
 ### References
 -------
 - Moore, D. S., McCabe, G. P., & Craig, B. A. (2012). *Introduction to the practice of statistics (7th ed.)*. New York, NY: W. H. Freeman and Company.
 - Sellke, T., Bayarri, M. J., & Berger, J. O. (2001). Calibration of *p* values for testing precise null hypotheses. *The American Statistician, 55*(1), 62-71.
+- Silverman, B. W. (1986). *Density Estimation*. London: Chapman and Hall.
 - Whitlock, M. C., & Schluter, D. (2015). *The analysis of biological data (2nd ed.)*. Greenwood Village, Colorado: Roberts and Company Publishers.
 
 ### R-packages

--- a/inst/help/ttestpairedsamples.md
+++ b/inst/help/ttestpairedsamples.md
@@ -33,6 +33,9 @@ The paired samples t-test allows the user to estimate the effect size  and test 
 - Descriptives: Sample size, sample mean, sample standard deviation, standard error of the mean for each measure. 
 - Descriptive plots: Displays the sample means and the confidence intervals for each measure (see Morey [2008] for the computation of the standard error of the mean in paired designs).
   - Confidence interval: Coverage of the confidence intervals in percentages. By default, the confidence interval is set to 95%. This can be changeed into the desired percentage.
+- Raincloud plots: Displays the individual cases (colored dots), box plots, and densities for each measure. 
+- Raincloud difference plots: Displays a raincloud plot of the differences between the two measures.
+  - Horizontal display: Changes the orientation of the raincloud difference plot so that the x-axis represents the dependent variable and the y-axis the difference between measures.
 - Vovk-Sellke Maximum *p*-Ratio: The bound 1/(-e *p* log(*p*)) is derived from the shape of the *p*-value distribution. Under the null hypothesis (H<sub>0</sub>) it is uniform(0,1), and under the alternative (H<sub>1</sub>) it is decreasing in *p*, e.g., a beta(&#945;, 1) distribution, where 0 < &#945; < 1. The Vovk-Sellke MPR is obtained by choosing the shape &#945; of the distribution under H<sub>1</sub> such that the obtained *p*-value is *maximally diagnostic*. The value is then the ratio of the densities at point *p* under H<sub>0</sub> and H<sub>1</sub>. For example, if the two-sided *p*-value equals .05, the Vovk-Sellke MPR equals 2.46, indicating that this *p*-value is at most 2.46 times more likely to occur under H<sub>1</sub> than under H<sub>0</sub>.
 
 #### Missing Values 
@@ -76,11 +79,18 @@ Test of Normality (Shapiro-Wilk)
 ##### Descriptive Plots 
 - Displays the sample means (black bullet), the % confidence intervals (whiskers) for each measure.  
 
+##### Raincloud Plots
+- Displays the individual cases (colored dots), box plots, and densities for each measure. The cases from both measures are connected with individual lines. The x-axis and color represent the measures, and the y-axis represents the dependent variable. Within the box plots, the bold black line shows the sample median, the hinges indicate the 25th and 75th quantile, and the whiskers point to 1.5 interquartile ranges beyond the hinges. Densities are estimated using a Gaussian kernel and the bandwidth is determined with the 'nrd0' method (Silverman, 1986).
+
+##### Raincloud Difference Plots
+- Displays the individual cases (colored dots), box plot, and density for the difference between the measures. The x-axis and color represent the measures, and the y-axis represents the dependent variable. Within the box plots, the bold black line shows the sample median, the hinges indicate the 25th and 75th quantile, and the whiskers point to 1.5 interquartile ranges beyond the hinges. Densities are estimated using a Gaussian kernel and the bandwidth is determined with the 'nrd0' method (Silverman, 1986).
+
 ### References
 -------
 - Moore, D. S., McCabe, G. P., & Craig, B. A. (2012). *Introduction to the practice of statistics (7th ed.)*. New York, NY: W. H. Freeman and Company.
 - Morey, R. D. (2008). Confidence intervals from normalized data: A correction to Cousineau (2005). *Tutorials in Quantitative Methods for Psychology, 4*, 61-64.
 - Sellke, T., Bayarri, M. J., & Berger, J. O. (2001). Calibration of *p* values for testing precise null hypotheses. *The American Statistician, 55*(1), 62-71.
+- Silverman, B. W. (1986). *Density Estimation*. London: Chapman and Hall.
 - Whitlock, M. C., & Schluter, D. (2015). *The analysis of biological data (2nd ed.)*. Greenwood Village, Colorado: Roberts and Company Publishers.
 
 


### PR DESCRIPTION
Fixes jasp-stats/INTERNAL-jasp#1478
Fixes jasp-stats/INTERNAL-jasp#1465
Fixes jasp-stats/jasp-test-release#1478
Fixes jasp-stats/jasp-test-release#1479

Adds:
- error checks and messages
- help file entries

for all t-test raincloud plots