### PR TITLE
Fix raincloud dependencies

### DIFF
--- a/R/commonTTest.R
+++ b/R/commonTTest.R
@@ -129,8 +129,8 @@
     return()
   if (is.null(jaspResults[["ttestDescriptives"]])) {
     container <- createJaspContainer(gettext("Descriptives"))
-    container$dependOn(c("descriptives", "descriptivesPlots", "descriptivesPlotsConfidenceInterval",
-                         "descriptivesPlotsRainCloud", "descriptivesPlotsRainCloudDifference",
+    container$dependOn(c(#"descriptives", "descriptivesPlots", "descriptivesPlotsConfidenceInterval",
+                         #"descriptivesPlotsRainCloud", "descriptivesPlotsRainCloudDifference",
                          "missingValues", "variables", "pairs", "groupingVariable"))
     container$position <- 3
     jaspResults[["ttestDescriptives"]] <- container

--- a/R/commonTTest.R
+++ b/R/commonTTest.R
@@ -129,9 +129,7 @@
     return()
   if (is.null(jaspResults[["ttestDescriptives"]])) {
     container <- createJaspContainer(gettext("Descriptives"))
-    container$dependOn(c(#"descriptives", "descriptivesPlots", "descriptivesPlotsConfidenceInterval",
-                         #"descriptivesPlotsRainCloud", "descriptivesPlotsRainCloudDifference",
-                         "missingValues", "variables", "pairs", "groupingVariable"))
+    container$dependOn(c("missingValues", "variables", "pairs", "groupingVariable"))
     container$position <- 3
     jaspResults[["ttestDescriptives"]] <- container
   }

--- a/R/commonbayesianttest.R
+++ b/R/commonbayesianttest.R
@@ -2135,16 +2135,21 @@
 }
 
 .ttestBayesianRainCloudPlots <- function(jaspResults, dataset, options, analysis) {
-  if (is.null(options$descriptivesPlotsRainCloud))
+  if (is.null(options$descriptivesPlotsRainCloud) || !options$descriptivesPlotsRainCloud)
     return()
-  if (!options$descriptivesPlotsRainCloud)
-    return()
+
   .ttestDescriptivesContainer(jaspResults, options)
   container <- jaspResults[["ttestDescriptives"]]
-  container[["plotsRainCloud"]] <- createJaspContainer(gettext("Raincloud Plots"))
-  subcontainer <- container[["plotsRainCloud"]]
-  subcontainer$dependOn(c("descriptivesPlotsRainCloud", "descriptivesPlotsRainCloudHorizontalDisplay"))
-  subcontainer$position <- 6
+
+  if (is.null(container[["plotsRainCloud"]])) {
+    subcontainer <- createJaspContainer(gettext("Raincloud Plots"))
+    subcontainer$dependOn(c("descriptivesPlotsRainCloud", "descriptivesPlotsRainCloudHorizontalDisplay"))
+    subcontainer$position <- 6
+    container[["plotsRainCloud"]] <- subcontainer
+  } else {
+    subcontainer <- container[["plotsRainCloud"]]
+  }
+
   horiz <- options$descriptivesPlotsRainCloudHorizontalDisplay
   errors <- .ttestBayesianGetErrorsPerVariable(dataset, options, analysis)
   if (analysis == "one-sample") {
@@ -2209,16 +2214,21 @@
 }
 
 .ttestBayesianRainCloudDifferencePlots <- function(jaspResults, dataset, options, analysis) {
-  if (is.null(options$descriptivesPlotsRainCloudDifference) || analysis != "paired")
+  if (is.null(options$descriptivesPlotsRainCloudDifference) || analysis != "paired" || !options$descriptivesPlotsRainCloudDifference)
     return()
-  if (!options$descriptivesPlotsRainCloudDifference)
-    return()
+
   .ttestDescriptivesContainer(jaspResults, options)
   container <- jaspResults[["ttestDescriptives"]]
-  container[["plotsRainCloudDifference"]] <- createJaspContainer(gettext("Raincloud Difference Plots"))
-  subcontainer <- container[["plotsRainCloudDifference"]]
-  subcontainer$dependOn(c("descriptivesPlotsRainCloudDifference", "descriptivesPlotsRainCloudDifferenceHorizontalDisplay"))
-  subcontainer$position <- 7
+
+  if (is.null(container[["plotsRainCloudDifference"]])) {
+    subcontainer <- createJaspContainer(gettext("Raincloud Difference Plots"))
+    subcontainer$dependOn(c("descriptivesPlotsRainCloudDifference", "descriptivesPlotsRainCloudDifferenceHorizontalDisplay"))
+    subcontainer$position <- 7
+    container[["plotsRainCloudDifference"]] <- subcontainer
+  } else {
+    subcontainer <- container[["plotsRainCloudDifference"]]
+  }
+
   horiz <- options$descriptivesPlotsRainCloudDifferenceHorizontalDisplay
   errors <- .ttestBayesianGetErrorsPerVariable(dataset, options, analysis)
   for(pair in options$pairs) {

--- a/R/ttestindependentsamples.R
+++ b/R/ttestindependentsamples.R
@@ -31,27 +31,27 @@ TTestIndependentSamples <- function(jaspResults, dataset = NULL, options, ...) {
   .ttestIndependentDescriptivesTable(        jaspResults, dataset, options, ready)
   .ttestIndependentDescriptivesPlot(         jaspResults, dataset, options, ready)
   .ttestIndependentDescriptivesRainCloudPlot(jaspResults, dataset, options, ready)
-  
+
   return()
 }
 
 .ttestIndependentMainTable <- function(jaspResults, dataset, options, ready, type) {
-  if (!is.null(jaspResults[["ttest"]])) 
+  if (!is.null(jaspResults[["ttest"]]))
     return()
-  
+
   optionsList <- .ttestOptionsList(options, type)
-  
+
   # Create table
   ttest <- createJaspTable(title = gettext("Independent Samples T-Test"))
   ttest$dependOn(c("effectSize", "effSizeConfidenceIntervalCheckbox", "variables",
                    "descriptivesEffectSizeConfidenceIntervalPercent", "students", "mannWhitneyU",
                    "meanDifference", "meanDiffConfidenceIntervalCheckbox", "stddev",
-                   "meanDiffConfidenceIntervalPercent", "hypothesis", 
-                   "VovkSellkeMPR", "missingValues", "groupingVariable", "effectSizesType", 
+                   "meanDiffConfidenceIntervalPercent", "hypothesis",
+                   "VovkSellkeMPR", "missingValues", "groupingVariable", "effectSizesType",
                    "welchs", "mannWhitneyU", "descriptivesMeanDiffConfidenceIntervalPercent"))
   ttest$showSpecifiedColumnsOnly <- TRUE
   ttest$position <- 1
-  
+
   if (optionsList$wantsWilcox && optionsList$onlyTest) {
     ttest$addFootnote(gettext("Mann-Whitney U test."))
     testStat <- "W"
@@ -68,32 +68,32 @@ TTestIndependentSamples <- function(jaspResults, dataset = NULL, options, ...) {
     testStat     <- "Statistic"
     testStatName <- gettext("Statistic")
   }
-  
+
   dfType <- ifelse(optionsList$wantsWelchs, "number", "integer")
-  
+
   ttest$addColumnInfo(name = "v", title = " ", type = "string", combine = TRUE)
-  
-  if (sum(optionsList$allTests) >= 2) 
+
+  if (sum(optionsList$allTests) >= 2)
     ttest$addColumnInfo(name = "test", type = "string",  title = gettext("Test"))
-  
+
   ttest$addColumnInfo(name = testStat, type = "number",  title = testStatName)
   ttest$addColumnInfo(name = "df",     type = dfType,    title = gettext("df"))
   ttest$addColumnInfo(name = "p",      type = "pvalue",  title = gettext("p"))
-  
+
   .ttestVovkSellke(ttest, options)
-  
+
   if (options$effectSizesType == "cohensD")
     effSize <- "cohen"
   else if (options$effectSizesType == "glassD")
     effSize <- "glass"
   else if (options$effectSizesType == "hedgesG")
     effSize <- "hedges"
-  
-  nameOfEffectSizeParametric <- switch(effSize, 
-                                       cohen  = gettext("Cohen's d"), 
+
+  nameOfEffectSizeParametric <- switch(effSize,
+                                       cohen  = gettext("Cohen's d"),
                                        glass  = gettext("Glass' delta"),
                                        hedges = gettext("Hedges' g"))
-  
+
   if (!optionsList$wantsWilcox) {
     nameOfLocationParameter <- gettext("Mean Difference")
     nameOfEffectSize        <- nameOfEffectSizeParametric
@@ -104,54 +104,54 @@ TTestIndependentSamples <- function(jaspResults, dataset = NULL, options, ...) {
     nameOfLocationParameter <-  gettext("Location Parameter")
     nameOfEffectSize        <-  gettext("Effect Size")
   }
-  
+
   if (optionsList$wantsStudents && optionsList$wantsWelchs)
     testInNote <- gettext("Student t-test and Welch t-test")
   else if (optionsList$wantsStudents)
     testInNote <- gettext("Student t-test")
   else if (optionsList$wantsWelchs)
     testInNote <- gettext("Welch t-test")
-  
+
   ## add mean difference and standard error difference
   if (optionsList$wantsDifference) {
     ttest$addColumnInfo(name = "md", title = nameOfLocationParameter, type = "number")
-    
+
     if (!(optionsList$wantsWilcox && optionsList$onlyTest))  # Only add SE Difference if not only MannWhitney is requested
       ttest$addColumnInfo(name = "sed", title = gettext("SE Difference"), type = "number")
-    
+
     if (optionsList$wantsWilcox && (optionsList$wantsStudents || optionsList$wantsWelchs))
       ttest$addFootnote(gettextf("For the %s, location parameter is given by mean difference. For the Mann-Whitney test, location parameter is given by the Hodges-Lehmann estimate.", testInNote))
   }
-  
+
   if (optionsList$wantsConfidenceMeanDiff) {
     title <- gettextf("%1$s%% CI for %2$s", 100 * optionsList$percentConfidenceMeanDiff, nameOfLocationParameter)
     ttest$addColumnInfo(name = "lowerCIlocationParameter", type = "number", title = gettext("Lower"), overtitle = title)
     ttest$addColumnInfo(name = "upperCIlocationParameter", type = "number", title = gettext("Upper"), overtitle = title)
   }
-  
+
   ## add Cohen's d
   if (optionsList$wantsEffect) {
     ttest$addColumnInfo(name = "d", title = nameOfEffectSize, type = "number")
 
     if (optionsList$wantsWilcox) {
       wNote <- gettext("For the Mann-Whitney test, effect size is given by the rank biserial correlation.")
-      
+
       twNote <- NULL
-      if (optionsList$wantsStudents || optionsList$wantsWelchs) 
+      if (optionsList$wantsStudents || optionsList$wantsWelchs)
         twNote <- gettextf("For the %1$s, effect size is given by %2$s.", testInNote, nameOfEffectSizeParametric)
-      
+
       ttest$addFootnote(paste(twNote, wNote))
     }
   }
-  
+
   if (optionsList$wantsConfidenceEffSize) {
     title <- gettextf("%1$s%% CI for %2$s", 100 * optionsList$percentConfidenceEffSize, nameOfEffectSize)
     ttest$addColumnInfo(name = "lowerCIeffectSize", type = "number", title = gettext("Lower"), overtitle = title)
     ttest$addColumnInfo(name = "upperCIeffectSize", type = "number", title = gettext("Upper"), overtitle = title)
   }
-  
+
   jaspResults[["ttest"]] <- ttest
-  
+
   if (ready)
     .ttestIndependentMainFill(ttest, dataset, options, testStat, optionsList)
 }
@@ -160,24 +160,24 @@ TTestIndependentSamples <- function(jaspResults, dataset = NULL, options, ...) {
   # Container
   .ttestAssumptionCheckContainer(jaspResults, options, type)
   container <- jaspResults[["AssumptionChecks"]]
-  if (!options$normalityTests || !is.null(container[["ttestNormalTable"]])) 
+  if (!options$normalityTests || !is.null(container[["ttestNormalTable"]]))
     return()
   container <- jaspResults[["AssumptionChecks"]]
   # Create table
   ttestNormalTable <- createJaspTable(title = gettext("Test of Normality (Shapiro-Wilk)"))
   ttestNormalTable$showSpecifiedColumnsOnly <- TRUE
   ttestNormalTable$position <- 2
-  
+
   ttestNormalTable$addColumnInfo(name = "dep", type = "string", title = "", combine = TRUE)
   ttestNormalTable$addColumnInfo(name = "lev", type = "string", title = "")
   ttestNormalTable$addColumnInfo(name = "W",   type = "number", title = gettext("W"))
   ttestNormalTable$addColumnInfo(name = "p",   type = "pvalue", title = gettext("p"))
-  
+
   message <- gettext("Significant results suggest a deviation from normality.")
   ttestNormalTable$addFootnote(message)
-  
+
   container[["ttestNormalTable"]] <- ttestNormalTable
-  
+
   if (ready)
     .ttestIndependentNormalFill(ttestNormalTable, dataset, options)
 }
@@ -186,10 +186,10 @@ TTestIndependentSamples <- function(jaspResults, dataset = NULL, options, ...) {
   # Container
   .ttestAssumptionCheckContainer(jaspResults, options, type)
   container <- jaspResults[["AssumptionChecks"]]
-  
-  if (!options$equalityOfVariancesTests || !is.null(container[["equalityVariance"]])) 
+
+  if (!options$equalityOfVariancesTests || !is.null(container[["equalityVariance"]]))
     return()
-  
+
   # Create table
   equalityVariance <- createJaspTable(title = gettext("Test of Equality of Variances (Levene's)"))
   equalityVariance$showSpecifiedColumnsOnly <- TRUE
@@ -198,15 +198,15 @@ TTestIndependentSamples <- function(jaspResults, dataset = NULL, options, ...) {
   equalityVariance$addColumnInfo(name = "F",        type = "number",  title = gettext("F"))
   equalityVariance$addColumnInfo(name = "df",       type = "integer", title = gettext("df"))
   equalityVariance$addColumnInfo(name = "p",        type = "pvalue",  title = gettext("p"))
-  
+
   container[["equalityVariance"]] <- equalityVariance
-  
+
   if (ready)
     .ttestIndependentEqVarFill(equalityVariance, dataset, options)
 }
 
 .ttestIndependentMainFill <- function(table, dataset, options, testStat, optionsList) {
-  
+
   if (options$effectSizesType == "cohensD")
     effSize <- "cohen"
   else if (options$effectSizesType == "glassD")
@@ -215,31 +215,31 @@ TTestIndependentSamples <- function(jaspResults, dataset = NULL, options, ...) {
     effSize <- "hedges"
 
   levels <- levels(dataset[[ .v(options$groupingVariable) ]])
-  
+
   if (options$hypothesis == "groupOneGreater" || options$hypothesis == "groupTwoGreater") {
     directionNote <- ifelse(options$hypothesis == "groupOneGreater", gettext("greater"), gettext("less"))
     table$addFootnote(gettextf("For all tests, the alternative hypothesis specifies that group %1$s is %2$s than group %3$s.",
                                                 paste("<em>", levels[1], "</em>"), directionNote, paste("<em>", levels[2], "</em>")))
   }
-  
+
   ## for each variable specified, run each test that the user wants
   for (variable in options$variables) {
-    errors <- .hasErrors(dataset, 
-                         message = 'short', 
+    errors <- .hasErrors(dataset,
+                         message = 'short',
                          type = c('observations', 'variance', 'infinity'),
-                         all.target = variable, 
+                         all.target = variable,
                          all.grouping = options$groupingVariable,
                          observations.amount = '< 2')
-    
+
     for (test in optionsList$whichTests) {
-      
+
       row     <- list(v = variable, test = test, .isNewGroup = .ttestRowIsNewGroup(test, optionsList$whichTests))
       rowName <- paste(test, variable, sep = "-")
-      
+
       errorMessage <- NULL
       if (identical(errors, FALSE)) {
         result <- try(ttestIndependentMainTableRow(variable, dataset, test, testStat, effSize, optionsList, options))
-        
+
         if (!isTryError(result)) {
           row <- c(row, result[["row"]])
           if (result[["leveneViolated"]])
@@ -247,19 +247,19 @@ TTestIndependentSamples <- function(jaspResults, dataset = NULL, options, ...) {
         } else {
           errorMessage <- .extractErrorMessage(result)
         }
-        
+
       } else {
         errorMessage <- errors$message
       }
-      
+
       if (!is.null(errorMessage)) {
         row[[testStat]] <- NaN
         table$addFootnote(errorMessage, colNames = testStat, rowNames = rowName)
       }
-      
+
       table$addRows(row, rowNames = rowName)
     }
-    
+
     if (effSize == "glass") {
       ns  <- tapply(dataset[[.v(variable)]], dataset[[.v(options$groupingVariable)]], function(x) length(na.omit(x)))
       sdMessage <- gettextf("Glass' delta uses the standard deviation of group %1$s of variable %2$s.", names(ns[2]), options$groupingVariable)
@@ -273,16 +273,16 @@ ttestIndependentMainTableRow <- function(variable, dataset, test, testStat, effS
   ciMeanDiff <- optionsList$percentConfidenceMeanDiff
   f <- as.formula(paste(.v(variable), "~",
                         .v(options$groupingVariable)))
-  
+
   variableData <- dataset[[ .v(variable) ]]
   groupingData <- dataset[[ .v(options$groupingVariable) ]]
-  
+
   sds <- tapply(variableData, groupingData, sd, na.rm = TRUE)
   ms  <- tapply(variableData, groupingData, mean, na.rm = TRUE)
   ns  <- tapply(variableData, groupingData, function(x) length(na.omit(x)))
-  
+
   direction <- .ttestMainGetDirection(options$hypothesis)
-  
+
   if (test == "Mann-Whitney") {
     r <- stats::wilcox.test(f, data = dataset,
                             alternative = direction,
@@ -297,7 +297,7 @@ ttestIndependentMainTableRow <- function(variable, dataset, test, testStat, effS
     rankBisSE <- sqrt(4 * 1/(ns[1]*ns[2])^2 * wSE^2)
     zRankBis  <- atanh(d)
     if(direction == "two.sided")
-      confIntEffSize <- sort(c(tanh(zRankBis + qnorm((1-ciEffSize)/2)*rankBisSE), 
+      confIntEffSize <- sort(c(tanh(zRankBis + qnorm((1-ciEffSize)/2)*rankBisSE),
                                tanh(zRankBis + qnorm((1+ciEffSize)/2)*rankBisSE)))
     else if (direction == "less")
       confIntEffSize <- sort(c(-Inf, tanh(zRankBis + qnorm(ciEffSize)*rankBisSE)))
@@ -306,16 +306,16 @@ ttestIndependentMainTableRow <- function(variable, dataset, test, testStat, effS
   } else {
     r <- stats::t.test(f, data = dataset, alternative = direction,
                        var.equal = test != "Welch", conf.level = ciMeanDiff, paired = FALSE)
-    
+
     df   <- as.numeric(r$parameter)
     m    <- as.numeric(r$estimate[1]) - as.numeric(r$estimate[2])
     stat <- as.numeric(r$statistic)
-    
+
     num <-  (ns[1] - 1) * sds[1]^2 + (ns[2] - 1) * sds[2]^2
     sdPooled <- sqrt(num / (ns[1] + ns[2] - 2))
     if (test == "Welch")  # Use different SE when using Welch T test!
       sdPooled <- sqrt(((sds[1]^2) + (sds[2]^2)) / 2)
-    
+
     d <- "."
     if (optionsList$wantsEffect) {
       # Sources are https://en.wikipedia.org/wiki/Effect_size for now.
@@ -332,21 +332,21 @@ ttestIndependentMainTableRow <- function(variable, dataset, test, testStat, effS
     }
     sed <- (as.numeric(r$estimate[1]) - as.numeric(r$estimate[2])) / stat
     confIntEffSize <- c(0,0)
-    
+
     if (optionsList$wantsConfidenceEffSize){
       # From MBESS package by Ken Kelley, v4.6
       dfEffSize  <-  ifelse(effSize == "glass", ns[2] - 1, df)
       alphaLevel <- ifelse(direction == "two.sided", 1 - (ciEffSize + 1) / 2, 1 - ciEffSize)
-      confIntEffSize <- .confidenceLimitsEffectSizes(ncp = d * sqrt((prod(ns)) / (sum(ns))), 
-                                                     df = dfEffSize, alpha.lower = alphaLevel, 
+      confIntEffSize <- .confidenceLimitsEffectSizes(ncp = d * sqrt((prod(ns)) / (sum(ns))),
+                                                     df = dfEffSize, alpha.lower = alphaLevel,
                                                      alpha.upper = alphaLevel)[c(1, 3)]
       confIntEffSize <- unlist(confIntEffSize) * sqrt((sum(ns)) / (prod(ns)))
-      
+
       if (direction == "greater")
         confIntEffSize[2] <- Inf
       else if (direction == "less")
         confIntEffSize[1] <- -Inf
-      
+
       confIntEffSize <- sort(confIntEffSize)
     }
   }
@@ -357,88 +357,88 @@ ttestIndependentMainTableRow <- function(variable, dataset, test, testStat, effS
   leveneViolated <- FALSE
   if (!optionsList$wantsWelchs && !optionsList$wantsWilcox && optionsList$wantsStudents) {
     levene <- car::leveneTest(variableData, groupingData, "mean")
-    
+
     ## arbitrary cut-offs are arbitrary
     if (!is.na(levene[1, 3]) && levene[1, 3] < 0.05)
       leveneViolated <- TRUE
   }
-  
+
   ## same for all t-tests
   p     <- as.numeric(r$p.value)
   ciLow <- r$conf.int[1]
   ciUp  <- r$conf.int[2]
   lowerCIeffectSize <- as.numeric(confIntEffSize[1])
   upperCIeffectSize <- as.numeric(confIntEffSize[2])
-  
+
   # this will be the results object
-  row <- list(df = df, p = p, md = m, d = d, 
+  row <- list(df = df, p = p, md = m, d = d,
               lowerCIlocationParameter = ciLow, upperCIlocationParameter = ciUp,
               lowerCIeffectSize = lowerCIeffectSize, upperCIeffectSize = upperCIeffectSize,
               sed = sed)
-  
+
   row[[testStat]] <- stat
-  
+
   if (options$VovkSellkeMPR)
     row[["VovkSellkeMPR"]] <- VovkSellkeMPR(p)
-  
+
   return(list(row = row, leveneViolated = leveneViolated))
 }
 
 .ttestIndependentEqVarFill <- function(table, dataset, options) {
   variables <- options$variables
   groups    <- options$groupingVariable
-  
+
   levels <- levels(dataset[[ .v(groups) ]])
-  
+
   for (variable in variables) {
-    
+
     row <- list(variable = variable)
-    
-    errors <- .hasErrors(dataset, 
-                        message = 'short', 
+
+    errors <- .hasErrors(dataset,
+                        message = 'short',
                         type = c('observations', 'variance', 'infinity'),
                         all.target = variable,
                         observations.amount = c('< 3'),
                         all.grouping = groups)
-    
+
     errorMessage <- NULL
     if (identical(errors, FALSE)) {
       result <- try(.ttestIndependentEqVarRow(table, variable, groups, dataset))
-      
+
       if (!isTryError(result))
         row <- c(row, result[["row"]])
       else
         errorMessage <- .extractErrorMessage(result)
-      
+
     } else {
       errorMessage <- errors$message
     }
-    
+
     if (!is.null(errorMessage)) {
       row[["F"]] <- NaN
       table$addFootnote(errors$message, colNames = "F", rowNames = variable)
     }
-    
+
     if (!result[["LeveneComputed"]])
       table$addFootnote(gettext("F-statistic could not be calculated"), colNames = "F", rowNames = variable)
-    
+
     table$addRows(row, rowNames = variable)
   }
 }
 
 .ttestIndependentEqVarRow <- function(table, variable, groups, dataset) {
   levene <- car::leveneTest(dataset[[ .v(variable) ]], dataset[[ .v(groups) ]], "mean")
-  
+
   F  <- levene[1, "F value"]
   df <- levene[1, "Df"]
   p  <- levene[1, "Pr(>F)"]
-  
+
   row <- list(F = F, df = df, p = p)
-  
+
   LeveneComputed <- TRUE
   if (is.na(levene[1, "F value"]))
     LeveneComputed <- FALSE
-  
+
   return(list(row = row, LeveneComputed = LeveneComputed))
 }
 
@@ -447,22 +447,22 @@ ttestIndependentMainTableRow <- function(variable, dataset, test, testStat, effS
   variables <- options$variables
   factor    <- options$groupingVariable
   levels    <- levels(dataset[[.v(factor)]])
-  
+
   for (variable in variables) {
     ## there will be two levels, otherwise .hasErrors will quit
     for (level in levels) {
 
       row     <- list(dep = variable, lev = level, .isNewGroup = (level == levels[1]))
       rowName <- paste(variable, level, sep = "-")
-      
-      errors <- .hasErrors(dataset, 
-                           message = 'short', 
+
+      errors <- .hasErrors(dataset,
+                           message = 'short',
                            type = c('observations', 'variance', 'infinity'),
                            all.target = variable,
                            observations.amount = c('< 3', '> 5000'),
                            all.grouping = factor,
                            all.groupingLevel = level)
-      
+
       if (!identical(errors, FALSE)) {
         row[["W"]] <- NaN
         table$addFootnote(errors$message, colNames = "W", rowNames = rowName)
@@ -483,7 +483,7 @@ ttestIndependentMainTableRow <- function(variable, dataset, test, testStat, effS
   # Container
   .ttestDescriptivesContainer(jaspResults, options)
   container <- jaspResults[["ttestDescriptives"]]
-  if (!options$descriptives || !is.null(container[["table"]])) 
+  if (!options$descriptives || !is.null(container[["table"]]))
     return()
   # Create table
   ttestDescriptivesTable <- createJaspTable(title = "Group Descriptives")
@@ -495,9 +495,9 @@ ttestIndependentMainTableRow <- function(variable, dataset, test, testStat, effS
   ttestDescriptivesTable$addColumnInfo(name = "mean",     type = "number",  title = gettext("Mean"))
   ttestDescriptivesTable$addColumnInfo(name = "sd",       type = "number",  title = gettext("SD"))
   ttestDescriptivesTable$addColumnInfo(name = "se",       type = "number",  title = gettext("SE"))
-  
+
   container[["table"]] <- ttestDescriptivesTable
-  
+
   if(ready)
     .ttestIndependentDescriptivesFill(ttestDescriptivesTable, dataset, options)
 }
@@ -507,31 +507,31 @@ ttestIndependentMainTableRow <- function(variable, dataset, test, testStat, effS
   groups <- options$groupingVariable
   levels <- base::levels(dataset[[ .v(groups) ]])
   groupingData <- dataset[[.v(groups)]]
-  
+
   for (variable in variables) {
-    
+
     for (level in levels) {
-      
+
       row <- list(variable = variable, group = level, .isNewGroup = (level == levels[1]))
-      
+
       variableData <- dataset[[.v(variable)]]
       groupData   <- variableData[groupingData == level]
       groupDataOm <- na.omit(groupData)
-      
+
       if (class(groupDataOm) != "factor") {
-        
+
         n    <- length(groupDataOm)
         mean <- mean(groupDataOm)
         std  <- sd(groupDataOm)
         sem  <- std / sqrt(n)
-        
+
         row <- c(row, list(N = n, mean = mean, sd = std, se = sem))
-        
+
       } else {
         n   <- length(groupDataOm)
         row <- c(row, list(n = n))
       }
-      
+
       table$addRows(row)
     }
   }
@@ -564,26 +564,26 @@ ttestIndependentMainTableRow <- function(variable, dataset, test, testStat, effS
 
 .ttestIndependentDescriptivesPlotFill <- function(dataset, options, variable) {
   groups   <- options$groupingVariable
-  
-  errors <- .hasErrors(dataset, 
-                       message = 'short', 
+
+  errors <- .hasErrors(dataset,
+                       message = 'short',
                        type = c('observations', 'variance', 'infinity'),
                        all.target = variable,
                        observations.amount = '< 2',
                        observations.grouping = groups)
-  
+
   if(!identical(errors, FALSE))
     stop(errors$message)
-  
+
   descriptivesPlotList <- list()
-  
+
   base_breaks_x <- function(x) {
     b <- unique(as.numeric(x))
     d <- data.frame(y = -Inf, yend = -Inf, x = min(b), xend = max(b))
     list(ggplot2::geom_segment(data = d, ggplot2::aes(x = x, y = y, xend = xend,
                                                       yend = yend), inherit.aes = FALSE, size = 1))
   }
-  
+
   base_breaks_y <- function(x) {
     ci.pos <- c(x[, "dependent"] - x[, "ci"], x[, "dependent"] + x[, "ci"])
     b <- pretty(ci.pos)
@@ -592,31 +592,31 @@ ttestIndependentMainTableRow <- function(variable, dataset, test, testStat, effS
                                                       yend = yend), inherit.aes = FALSE, size = 1),
          ggplot2::scale_y_continuous(breaks = c(min(b), max(b))))
   }
-  
+
   dataset <- na.omit(dataset[, c(.v(groups), .v(variable))])
   ci <- options$descriptivesPlotsConfidenceInterval
   summaryStat <- summarySE(as.data.frame(dataset),
                            measurevar = .v(variable),
                            groupvars = .v(groups),
                            conf.interval = ci, na.rm = TRUE, .drop = FALSE)
-  
+
   colnames(summaryStat)[which(colnames(summaryStat) == .v(variable))] <- "dependent"
   colnames(summaryStat)[which(colnames(summaryStat) == .v(groups))]   <- "groupingVariable"
-  
+
   pd <- ggplot2::position_dodge(0.2)
-  
+
   p <- ggplot2::ggplot(summaryStat, ggplot2::aes(x = groupingVariable,
-                                                 y = dependent, group = 1)) + 
-    ggplot2::geom_errorbar(ggplot2::aes(ymin = ciLower, ymax = ciUpper), 
+                                                 y = dependent, group = 1)) +
+    ggplot2::geom_errorbar(ggplot2::aes(ymin = ciLower, ymax = ciUpper),
                            colour = "black", width = 0.2, position = pd) +
-    ggplot2::geom_line(position = pd, size = 0.7) + 
-    ggplot2::geom_point(position = pd, size = 4) + 
-    ggplot2::ylab(unlist(variable)) + 
+    ggplot2::geom_line(position = pd, size = 0.7) +
+    ggplot2::geom_point(position = pd, size = 4) +
+    ggplot2::ylab(unlist(variable)) +
     ggplot2::xlab(options$groupingVariable) +
     base_breaks_y(summaryStat) + base_breaks_x(summaryStat$groupingVariable)
-  
+
   p <- jaspGraphs::themeJasp(p)
-  
+
   return(p)
 }
 

--- a/R/ttestindependentsamples.R
+++ b/R/ttestindependentsamples.R
@@ -542,9 +542,14 @@ ttestIndependentMainTableRow <- function(variable, dataset, test, testStat, effS
     return()
   .ttestDescriptivesContainer(jaspResults, options)
   container <- jaspResults[["ttestDescriptives"]]
-  container[["plots"]] <- createJaspContainer(gettext("Descriptives Plots"))
-  subcontainer <- container[["plots"]]
-  subcontainer$position <- 5
+  if (is.null(container[["plots"]])) {
+    subcontainer <- createJaspContainer(gettext("Descriptives Plots"))
+    subcontainer$position <- 5
+    container[["plots"]] <- subcontainer
+  } else {
+    subcontainer <- container[["plots"]]
+  }
+
   for(variable in options$variables) {
     if(!is.null(subcontainer[[variable]]))
       next
@@ -625,9 +630,13 @@ ttestIndependentMainTableRow <- function(variable, dataset, test, testStat, effS
     return()
   .ttestDescriptivesContainer(jaspResults, options)
   container <- jaspResults[["ttestDescriptives"]]
-  container[["plotsRainCloud"]] <- createJaspContainer(gettext("Raincloud Plots"))
-  subcontainer <- container[["plotsRainCloud"]]
-  subcontainer$position <- 6
+
+  if (is.null(container[["plotsRainCloud"]])) {
+    subcontainer <- createJaspContainer(gettext("Raincloud Plots"))
+    subcontainer$position <- 6
+  } else {
+    subcontainer <- container[["plotsRainCloud"]]
+  }
   horiz <- options$descriptivesPlotsRainCloudHorizontalDisplay
   if(ready){
     groups <- options$groupingVariable

--- a/R/ttestindependentsamples.R
+++ b/R/ttestindependentsamples.R
@@ -486,7 +486,7 @@ ttestIndependentMainTableRow <- function(variable, dataset, test, testStat, effS
   if (!options$descriptives || !is.null(container[["table"]]))
     return()
   # Create table
-  ttestDescriptivesTable <- createJaspTable(title = "Group Descriptives")
+  ttestDescriptivesTable <- createJaspTable(title = "Group Descriptives", dependencies = "descriptives")
   ttestDescriptivesTable$showSpecifiedColumnsOnly <- TRUE
   ttestDescriptivesTable$position <- 4
   ttestDescriptivesTable$addColumnInfo(name = "variable", type = "string",  title = "", combine = TRUE)
@@ -543,7 +543,7 @@ ttestIndependentMainTableRow <- function(variable, dataset, test, testStat, effS
   .ttestDescriptivesContainer(jaspResults, options)
   container <- jaspResults[["ttestDescriptives"]]
   if (is.null(container[["plots"]])) {
-    subcontainer <- createJaspContainer(gettext("Descriptives Plots"))
+    subcontainer <- createJaspContainer(gettext("Descriptives Plots"), dependencies = c("descriptivesPlots", "descriptivesPlotsConfidenceInterval"))
     subcontainer$position <- 5
     container[["plots"]] <- subcontainer
   } else {
@@ -632,7 +632,7 @@ ttestIndependentMainTableRow <- function(variable, dataset, test, testStat, effS
   container <- jaspResults[["ttestDescriptives"]]
 
   if (is.null(container[["plotsRainCloud"]])) {
-    subcontainer <- createJaspContainer(gettext("Raincloud Plots"))
+    subcontainer <- createJaspContainer(gettext("Raincloud Plots"), dependencies = c("descriptivesPlotsRainCloud", "descriptivesPlotsRainCloudHorizontalDisplay"))
     subcontainer$position <- 6
   } else {
     subcontainer <- container[["plotsRainCloud"]]

--- a/R/ttestindependentsamples.R
+++ b/R/ttestindependentsamples.R
@@ -634,6 +634,7 @@ ttestIndependentMainTableRow <- function(variable, dataset, test, testStat, effS
   if (is.null(container[["plotsRainCloud"]])) {
     subcontainer <- createJaspContainer(gettext("Raincloud Plots"), dependencies = c("descriptivesPlotsRainCloud", "descriptivesPlotsRainCloudHorizontalDisplay"))
     subcontainer$position <- 6
+    container[["plotsRainCloud"]] <- subcontainer
   } else {
     subcontainer <- container[["plotsRainCloud"]]
   }

--- a/R/ttestonesample.R
+++ b/R/ttestonesample.R
@@ -30,26 +30,26 @@ TTestOneSample <- function(jaspResults, dataset = NULL, options, ...) {
   .ttestDescriptivesTable(                 jaspResults, dataset, options, ready, vars)
   .ttestOneSampleDescriptivesPlot(         jaspResults, dataset, options, ready)
   .ttestOneSampleDescriptivesRainCloudPlot(jaspResults, dataset, options, ready)
-  
+
   return()
 }
 
 .ttestOneSampleMainTable <- function(jaspResults, dataset, options, ready, type) {
-  if (!is.null(jaspResults[["ttest"]])) 
+  if (!is.null(jaspResults[["ttest"]]))
     return()
-  
+
   optionsList <- .ttestOptionsList(options, type)
-  
+
   # Create table
   ttest <- createJaspTable(title = gettext("One Sample T-Test"))
   ttest$dependOn(c("effectSize", "effSizeConfidenceIntervalCheckbox", "variables",
                    "effSizeConfidenceIntervalPercent", "students", "mannWhitneyU",
                    "meanDifference", "meanDiffConfidenceIntervalCheckbox", "stddev",
-                   "meanDiffConfidenceIntervalPercent", "hypothesis", 
+                   "meanDiffConfidenceIntervalPercent", "hypothesis",
                    "VovkSellkeMPR", "missingValues", "zTest", "testValue"))
   ttest$showSpecifiedColumnsOnly <- TRUE
   ttest$position <- 1
-  
+
   if (optionsList$wantsWilcox && optionsList$onlyTest) {
     ttest$addFootnote(gettext("Wilcoxon signed-rank test."))
     testStat                <- "V"
@@ -74,76 +74,76 @@ TTestOneSample <- function(jaspResults, dataset = NULL, options, ...) {
     nameOfLocationParameter <- gettext("Location Difference")
     nameOfEffectSize        <- gettext("Effect Size")
   }
-  
+
   ttest$addColumnInfo(name = "v",     type = "string", title = "", combine = TRUE)
-  
+
   ## if the user wants more than one test, add a column called "Test"
-  if (sum(optionsList$allTests) > 1) 
+  if (sum(optionsList$allTests) > 1)
     ttest$addColumnInfo(name = "test", type = "string", title = gettext("Test"))
-  
+
   ttest$addColumnInfo(name = testStat, type = "number", title = testStatName)
-  
+
   if (optionsList$wantsStudents)
     ttest$addColumnInfo(name = "df", type = "integer", title = gettext("df"))
-  
+
   ttest$addColumnInfo(name = "p", type = "pvalue", title = gettext("p"))
-  
+
   .ttestVovkSellke(ttest, options)
-  
+
   if (optionsList$wantsStudents && optionsList$wantsZtest)
     testInNote <- gettext("Student t-test and Z-test")
   else if (optionsList$wantsStudents)
     testInNote <- gettext("Student t-test")
   else if (optionsList$wantsZtest)
     testInNote <- gettext("Z-test")
-  
+
   if (optionsList$wantsDifference) {
     ttest$addColumnInfo(name = "m", title = nameOfLocationParameter, type = "number")
-    
+
     if (optionsList$wantsStudents || optionsList$wantsZtest || optionsList$wantsWilcox) {
       tzNote <- wNote <- NULL
-      
+
       if (optionsList$wantsStudents || optionsList$wantsZtest)
         tzNote <- gettextf("For the %s, location difference estimate is given by the sample mean difference <em>d</em>.", testInNote)
-      
+
       if (optionsList$wantsWilcox)
         wNote <- gettext("For the Wilcoxon test, location difference estimate is given by the Hodges-Lehmann estimate.")
-      
+
       ttest$addFootnote(paste(tzNote, wNote))
     }
   }
-  
+
   if (optionsList$wantsConfidenceMeanDiff) {
     title <- gettextf("%1$s%% CI for %2$s", 100 * optionsList$percentConfidenceMeanDiff, nameOfLocationParameter)
     ttest$addColumnInfo(name = "lowerCIlocationParameter", type = "number", title = gettext("Lower"), overtitle = title)
     ttest$addColumnInfo(name = "upperCIlocationParameter", type = "number", title = gettext("Upper"), overtitle = title)
   }
-  
+
   if (optionsList$wantsEffect) {
     ttest$addColumnInfo(name = "d", title = nameOfEffectSize, type = "number")
-    
+
     if (optionsList$wantsStudents || optionsList$wantsWilcox || optionsList$wantsZtest) {
       tNote <- wNote <- zNote <- NULL
-      
+
       if (optionsList$wantsStudents)
         tNote <- gettext("For the Student t-test, effect size is given by Cohen's <em>d</em>.")
-      
+
       if (optionsList$wantsWilcox)
         wNote <- gettext("For the Wilcoxon test, effect size is given by the matched rank biserial correlation.")
-      
+
       if (optionsList$wantsZtest)
         zNote <- gettext("For the Z test, effect size is given by Cohen's <em>d</em> (based on the provided population standard deviation).")
-      
+
       ttest$addFootnote(paste(tNote, wNote, zNote))
     }
   }
-  
+
   if (optionsList$wantsConfidenceEffSize) {
     title <- gettextf("%1$s%% CI for %2$s", 100 * optionsList$percentConfidenceEffSize, nameOfEffectSize)
     ttest$addColumnInfo(name = "lowerCIeffectSize", type = "number", title = gettext("Lower"), overtitle = title)
     ttest$addColumnInfo(name = "upperCIeffectSize", type = "number", title = gettext("Upper"), overtitle = title)
   }
-  
+
   ### check the directionality
   if (options$hypothesis == "greaterThanTestValue") {
     directionFootnote <- gettext("greater than")
@@ -155,22 +155,22 @@ TTestOneSample <- function(jaspResults, dataset = NULL, options, ...) {
     directionFootnote <- gettext("different from")
     direction <- "two.sided"
   }
-  
+
   if (optionsList$wantsStudents || optionsList$wantsWilcox || optionsList$wantsZtest) {
     tMessage <- wMessage <- NULL
-    
+
     if (optionsList$wantsStudents || optionsList$wantsZtest)
       tMessage <- gettextf("For the %1$s, the alternative hypothesis specifies that the mean is %2$s %3$s.", testInNote, directionFootnote, options$testValue)
-    
+
     if (optionsList$wantsWilcox)
       wMessage <- gettextf("For the Wilcoxon test, the alternative hypothesis specifies that the median is %1$s %2$s.", directionFootnote, options$testValue)
-    
+
     ttest$addFootnote(paste(tMessage, wMessage))
   }
-  
+
   jaspResults[["ttest"]] <- ttest
-  
-  if (ready) 
+
+  if (ready)
     .ttestOneSampleMainFill(ttest, dataset, options, testStat, optionsList)
 }
 
@@ -178,23 +178,23 @@ TTestOneSample <- function(jaspResults, dataset = NULL, options, ...) {
   # Container
   .ttestAssumptionCheckContainer(jaspResults, options, type)
   container <- jaspResults[["AssumptionChecks"]]
-  if (!options$normalityTests || !is.null(container[["ttestNormalTable"]])) 
+  if (!options$normalityTests || !is.null(container[["ttestNormalTable"]]))
     return()
   container <- jaspResults[["AssumptionChecks"]]
   # Create table
   ttestNormalTable <- createJaspTable(title = gettext("Test of Normality (Shapiro-Wilk)"))
   ttestNormalTable$showSpecifiedColumnsOnly <- TRUE
   ttestNormalTable$position <- 2
-  
+
   ttestNormalTable$addColumnInfo(name = "v", title = "",  type = "string")
   ttestNormalTable$addColumnInfo(name = "W", title = gettext("W"), type = "number")
   ttestNormalTable$addColumnInfo(name = "p", title = gettext("p"), type = "pvalue")
-  
+
   message <- gettext("Significant results suggest a deviation from normality.")
   ttestNormalTable$addFootnote(message)
-  
+
   container[["ttestNormalTable"]] <- ttestNormalTable
-  
+
   if (ready)
     .ttestOneSampleNormalFill(ttestNormalTable, dataset, options)
 }
@@ -202,41 +202,41 @@ TTestOneSample <- function(jaspResults, dataset = NULL, options, ...) {
 .ttestOneSampleMainFill <-function(table, dataset, options, testStat, optionsList) {
   variables <- options$variables
   for (variable in variables) {
-    
-    errors <- .hasErrors(dataset, 
-                         message = 'short', 
+
+    errors <- .hasErrors(dataset,
+                         message = 'short',
                          type = c('observations', 'variance', 'infinity'),
                          all.target = variable,
                          observations.amount = '< 2')
-    
+
     for (test in optionsList$whichTests) {
 
       row     <- list(v = variable, test = test, .isNewGroup = .ttestRowIsNewGroup(test, optionsList$whichTests))
       rowName <- paste(test, variable, sep = "-")
-      
+
       errorMessage <- NULL
       if (identical(errors, FALSE)) {
         rowResults <- try(.ttestOneSampleComputeMainTableRow(variable, dataset, test, testStat, optionsList, options))
-        
+
           if (!isTryError(rowResults))
             row <- c(row, rowResults)
           else
             errorMessage <- .extractErrorMessage(rowResults)
-          
+
       } else {
         errorMessage <- errors$message
       }
-      
+
       if (!is.null(errorMessage)) {
         row[[testStat]] <- NaN
         table$addFootnote(errorMessage, colNames = testStat, rowNames = rowName)
       }
-      
+
       table$addRows(row, rowNames = rowName)
     }
   }
 }
-  
+
 .ttestOneSampleComputeMainTableRow <- function(variable, dataset, test, testStat, optionsList, options) {
   direction <- switch(options[["hypothesis"]],
                       "notEqualToTestValue"  ="two.sided",
@@ -252,59 +252,59 @@ TTestOneSample <- function(jaspResults, dataset = NULL, options, ...) {
     maxw <- (nd * (nd + 1)) / 2
     d    <- as.numeric((tempResult[["statistic"]] / maxw) * 2 - 1)
     wSE  <- sqrt((nd * (nd + 1) * (2 * nd + 1)) / 6) /2
-    mrSE <- sqrt(wSE^2  * 4 * (1 / maxw^2)) 
+    mrSE <- sqrt(wSE^2  * 4 * (1 / maxw^2))
     # zSign <- (ww$statistic - ((n*(n+1))/4))/wSE
     zmbiss <- atanh(d)
-    
+
     if(direction == "two.sided")
-      confIntEffSize <- sort(c(tanh(zmbiss + qnorm((1-optionsList[["percentConfidenceEffSize"]])/2)*mrSE), 
+      confIntEffSize <- sort(c(tanh(zmbiss + qnorm((1-optionsList[["percentConfidenceEffSize"]])/2)*mrSE),
                                tanh(zmbiss + qnorm((1+optionsList[["percentConfidenceEffSize"]])/2)*mrSE)))
-    else if (direction == "less") 
+    else if (direction == "less")
       confIntEffSize <- sort(c(-Inf, tanh(zmbiss + qnorm(optionsList[["percentConfidenceEffSize"]])*mrSE)))
     else if (direction == "greater")
       confIntEffSize <- sort(c(tanh(zmbiss + qnorm((1-optionsList[["percentConfidenceEffSize"]]))*mrSE), Inf))
-    
+
   } else if (test == "Z"){
-    tempResult <- .z.test("x"=dat, "alternative" = direction, 
-                          "mu" = options[["testValue"]], "sigma.x" = options[["stddev"]], 
+    tempResult <- .z.test("x"=dat, "alternative" = direction,
+                          "mu" = options[["testValue"]], "sigma.x" = options[["stddev"]],
                           "ciValueMeanDiff"=optionsList[["percentConfidenceMeanDiff"]],
                           "ciValueESMeanDiff"=options[["effSizeConfidenceIntervalPercent"]])
-    
+
     df <- ""
     d  <- tempResult[["d"]]
-    
+
     confIntEffSize <- tempResult[["confIntEffSize"]]
   } else {
-    tempResult <- stats::t.test(dat, alternative = direction, mu = options[["testValue"]], 
+    tempResult <- stats::t.test(dat, alternative = direction, mu = options[["testValue"]],
                                 conf.level = optionsList[["percentConfidenceMeanDiff"]])
     df <- ifelse(is.null(tempResult[["parameter"]]), "", as.numeric(tempResult[["parameter"]]))
     d  <- (mean(dat) - options[["testValue"]]) / sd(dat)
     t  <- as.numeric(tempResult[["statistic"]])
-    
+
     confIntEffSize <- c(0,0)
-    
+
     if (optionsList[["wantsConfidenceEffSize"]]) {
-      
+
       ciEffSize  <- options[["effSizeConfidenceIntervalPercent"]]
       alphaLevel <- ifelse(direction == "two.sided", 1 - (ciEffSize + 1) / 2, 1 - ciEffSize)
-      
+
       confIntEffSize <- .confidenceLimitsEffectSizes(ncp = d * sqrt(n), df = df, alpha.lower = alphaLevel,
                                                      alpha.upper = alphaLevel)[c(1, 3)]
       confIntEffSize <- unlist(confIntEffSize) / sqrt(n)
-      
+
       if (direction == "greater")
         confIntEffSize[2] <- Inf
       else if (direction == "less")
         confIntEffSize[1] <- -Inf
-      
+
       confIntEffSize <- sort(confIntEffSize)
     }
   }
-  
+
   ## same for all tests
   p     <- as.numeric(tempResult[["p.value"]])
   stat  <- as.numeric(tempResult[["statistic"]])
-  
+
   if (test=="Z") {
     ciLow <- as.numeric(tempResult[["conf.int"]][1])
     ciUp  <- as.numeric(tempResult[["conf.int"]][2])
@@ -314,21 +314,21 @@ TTestOneSample <- function(jaspResults, dataset = NULL, options, ...) {
     ciLow <- as.numeric(tempResult[["conf.int"]][1] - tempResult[["null.value"]])
     ciUp  <- as.numeric(tempResult[["conf.int"]][2] - tempResult[["null.value"]])
   }
-  
+
   ciLowEffSize <- as.numeric(confIntEffSize[1])
   ciUpEffSize  <- as.numeric(confIntEffSize[2])
-  
-  if (suppressWarnings(is.na(t)))  # do not throw warning when test stat is not 't' 
+
+  if (suppressWarnings(is.na(t)))  # do not throw warning when test stat is not 't'
     stop("data are essentially constant")
-  
-  result <- list(df = df, p = p, m = m, d = d, 
-                 lowerCIlocationParameter = ciLow, upperCIlocationParameter = ciUp, 
+
+  result <- list(df = df, p = p, m = m, d = d,
+                 lowerCIlocationParameter = ciLow, upperCIlocationParameter = ciUp,
                  lowerCIeffectSize = ciLowEffSize, upperCIeffectSize = ciUpEffSize)
   result[[testStat]] <- stat
-  
+
   if (options[["VovkSellkeMPR"]])
     result[["VovkSellkeMPR"]] <- VovkSellkeMPR(p)
-  
+
   return(result)
 }
 
@@ -336,24 +336,24 @@ TTestOneSample <- function(jaspResults, dataset = NULL, options, ...) {
   variables <- options[["variables"]]
   for (variable in variables) {
     row <- list(v = variable)
-    
-    errors <- .hasErrors(dataset, 
-                         message = 'short', 
+
+    errors <- .hasErrors(dataset,
+                         message = 'short',
                          type = c('observations', 'variance', 'infinity'),
                          all.target = variable,
                          observations.amount = c('< 3', '> 5000'))
-    
+
     if (!identical(errors, FALSE)) {
       row[["W"]] <- NaN
       table$addFootnote(errors$message, colNames = "W", rowNames = variable)
     } else {
       data <- na.omit(dataset[[.v(variable)]])
-      
+
       tempResult <- stats::shapiro.test(data)
       row[["W"]] <- as.numeric(tempResult[["statistic"]])
       row[["p"]] <- tempResult[["p.value"]]
     }
-    
+
     table$addRows(row, rowNames = variable)
   }
 }
@@ -384,17 +384,17 @@ TTestOneSample <- function(jaspResults, dataset = NULL, options, ...) {
 }
 
 .ttestOneSampleDescriptivesPlotFill <- function(dataset, options, variable) {
-  errors <- .hasErrors(dataset, 
-                       message = 'short', 
+  errors <- .hasErrors(dataset,
+                       message = 'short',
                        type = c('observations', 'variance', 'infinity'),
                        all.target = variable,
                        observations.amount = c('< 2'))
   if(!identical(errors, FALSE))
     stop(errors$message)
-  
-  
+
+
   base_breaks_y <- function(x, options) {
-    
+
     values <- c(options$testValue, x[, "dependent"] - x[, "ci"],
                 x[, "dependent"] + x[, "ci"])
     ci.pos <- c(min(values), max(values))
@@ -404,27 +404,27 @@ TTestOneSample <- function(jaspResults, dataset = NULL, options, ...) {
                                                       yend = yend), inherit.aes = FALSE, size = 1),
          ggplot2::scale_y_continuous(breaks = c(min(b),  options$testValue, max(b))))
   }
-  
+
   dataSubset <- data.frame(dependent = dataset[[.v(variable)]],
                            groupingVariable = rep(variable, length(dataset[[.v(variable)]])))
-  
+
   ci <- options$descriptivesPlotsConfidenceInterval
   summaryStat <- summarySE(dataSubset, measurevar = "dependent",
                            groupvars = "groupingVariable",
                            conf.interval = ci, na.rm = TRUE, .drop = FALSE)
   testValue <- data.frame(testValue = options$testValue)
   pd <- ggplot2::position_dodge(0.2)
-  p <- ggplot2::ggplot(summaryStat, ggplot2::aes(x = groupingVariable, y = dependent, group = 1)) + 
-    ggplot2::geom_errorbar(ggplot2::aes(ymin = ciLower,  ymax = ciUpper), 
-                           colour = "black", width = 0.2, position = pd) + 
-    ggplot2::geom_line(position = pd, size = 0.7) +#gives geom_path warning+ 
-    ggplot2::geom_point(position = pd, size = 4)  + 
-    ggplot2::geom_hline(data = testValue, ggplot2::aes(yintercept = testValue), linetype = "dashed") + 
-    ggplot2::ylab(NULL) + ggplot2::xlab(NULL) + base_breaks_y(summaryStat, options) 
-  p <- jaspGraphs::themeJasp(p) + 
-    ggplot2::theme(axis.text.x = ggplot2::element_blank(), 
+  p <- ggplot2::ggplot(summaryStat, ggplot2::aes(x = groupingVariable, y = dependent, group = 1)) +
+    ggplot2::geom_errorbar(ggplot2::aes(ymin = ciLower,  ymax = ciUpper),
+                           colour = "black", width = 0.2, position = pd) +
+    ggplot2::geom_line(position = pd, size = 0.7) +#gives geom_path warning+
+    ggplot2::geom_point(position = pd, size = 4)  +
+    ggplot2::geom_hline(data = testValue, ggplot2::aes(yintercept = testValue), linetype = "dashed") +
+    ggplot2::ylab(NULL) + ggplot2::xlab(NULL) + base_breaks_y(summaryStat, options)
+  p <- jaspGraphs::themeJasp(p) +
+    ggplot2::theme(axis.text.x = ggplot2::element_blank(),
                    axis.ticks.x = ggplot2::element_blank())
-  
+
   return(p)
 }
 

--- a/R/ttestonesample.R
+++ b/R/ttestonesample.R
@@ -365,7 +365,7 @@ TTestOneSample <- function(jaspResults, dataset = NULL, options, ...) {
   container <- jaspResults[["ttestDescriptives"]]
 
   if (is.null(container[["plots"]])) {
-    subcontainer <- createJaspContainer(gettext("Descriptives Plots"))
+    subcontainer <- createJaspContainer(gettext("Descriptives Plots"), dependencies = c("descriptivesPlots", "descriptivesPlotsConfidenceInterval"))
     subcontainer$position <- 5
     container[["plots"]] <- subcontainer
   } else {
@@ -441,7 +441,7 @@ TTestOneSample <- function(jaspResults, dataset = NULL, options, ...) {
   container <- jaspResults[["ttestDescriptives"]]
 
   if (is.null(container[["plotsRainCloud"]])) {
-    subcontainer <- createJaspContainer(gettext("Raincloud Plots"))
+    subcontainer <- createJaspContainer(gettext("Raincloud Plots"), dependencies = c("descriptivesPlotsRainCloud", "descriptivesPlotsRainCloudHorizontalDisplay"))
     subcontainer$position <- 6
     container[["plotsRainCloud"]] <- subcontainer
   } else {

--- a/R/ttestonesample.R
+++ b/R/ttestonesample.R
@@ -363,9 +363,15 @@ TTestOneSample <- function(jaspResults, dataset = NULL, options, ...) {
     return()
   .ttestDescriptivesContainer(jaspResults, options)
   container <- jaspResults[["ttestDescriptives"]]
-  container[["plots"]] <- createJaspContainer(gettext("Descriptives Plots"))
-  subcontainer <- container[["plots"]]
-  subcontainer$position <- 5
+
+  if (is.null(container[["plots"]])) {
+    subcontainer <- createJaspContainer(gettext("Descriptives Plots"))
+    subcontainer$position <- 5
+    container[["plots"]] <- subcontainer
+  } else {
+    subcontainer <- container[["plots"]]
+  }
+
   for(variable in options$variables) {
     if(!is.null(subcontainer[[variable]]))
       next
@@ -433,9 +439,15 @@ TTestOneSample <- function(jaspResults, dataset = NULL, options, ...) {
     return()
   .ttestDescriptivesContainer(jaspResults, options)
   container <- jaspResults[["ttestDescriptives"]]
-  container[["plotsRainCloud"]] <- createJaspContainer(gettext("Raincloud Plots"))
-  subcontainer <- container[["plotsRainCloud"]]
-  subcontainer$position <- 6
+
+  if (is.null(container[["plotsRainCloud"]])) {
+    subcontainer <- createJaspContainer(gettext("Raincloud Plots"))
+    subcontainer$position <- 6
+    container[["plotsRainCloud"]] <- subcontainer
+  } else {
+    subcontainer <- container[["plotsRainCloud"]]
+  }
+
   horiz <- options$descriptivesPlotsRainCloudHorizontalDisplay
   if(ready){
     errors <- .ttestBayesianGetErrorsPerVariable(dataset, options, "one-sample")

--- a/R/ttestpairedsamples.R
+++ b/R/ttestpairedsamples.R
@@ -388,9 +388,14 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
     return()
   .ttestDescriptivesContainer(jaspResults, options)
   container <- jaspResults[["ttestDescriptives"]]
-  container[["plots"]] <- createJaspContainer(gettext("Descriptives Plots"))
-  subcontainer <- container[["plots"]]
-  subcontainer$position <- 5
+
+  if (is.null(container[["plots"]])) {
+    subcontainer <- createJaspContainer(gettext("Descriptives Plots"), dependencies = c("descriptivesPlots", "descriptivesPlotsConfidenceInterval"))
+    subcontainer$position <- 5
+  } else {
+    subcontainer <- container[["plots"]]
+  }
+
   for(pair in options$pairs) {
     title <- paste(pair, collapse = " - ")
     if(!is.null(subcontainer[[title]]))
@@ -464,9 +469,15 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
     return()
   .ttestDescriptivesContainer(jaspResults, options)
   container <- jaspResults[["ttestDescriptives"]]
-  container[["plotsRainCloud"]] <- createJaspContainer(gettext("Raincloud Plots"))
-  subcontainer <- container[["plotsRainCloud"]]
-  subcontainer$position <- 6
+
+  if (is.null(container[["plotsRainCloud"]])) {
+    subcontainer <- createJaspContainer(gettext("Raincloud Plots"))
+    subcontainer$position <- 6
+    container[["plotsRainCloud"]] <- subcontainer
+  } else {
+    subcontainer <- container[["plotsRainCloud"]]
+  }
+
   if(ready){
     errors <- .ttestBayesianGetErrorsPerVariable(dataset, options, "paired")
     for(pair in options$pairs) {
@@ -497,9 +508,15 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
     return()
   .ttestDescriptivesContainer(jaspResults, options)
   container <- jaspResults[["ttestDescriptives"]]
-  container[["plotsRainCloudDifference"]] <- createJaspContainer(gettext("Raincloud Difference Plots"))
-  subcontainer <- container[["plotsRainCloudDifference"]]
-  subcontainer$position <- 7
+
+  if (is.null(container[["plotsRainCloudDifference"]])) {
+    subcontainer <- createJaspContainer(gettext("Raincloud Difference Plots"), dependencies = c("descriptivesPlotsRainCloudDifference", "descriptivesPlotsRainCloudDifferenceHorizontalDisplay"))
+    subcontainer$position <- 7
+    container[["plotsRainCloudDifference"]] <- subcontainer
+  } else {
+    subcontainer <- container[["plotsRainCloudDifference"]]
+  }
+
   horiz <- options$descriptivesPlotsRainCloudDifferenceHorizontalDisplay
   if(ready){
     errors <- .ttestBayesianGetErrorsPerVariable(dataset, options, "paired")

--- a/R/ttestpairedsamples.R
+++ b/R/ttestpairedsamples.R
@@ -340,7 +340,7 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
   if (!options$descriptives || !is.null(container[["table"]]))
     return()
   # Create table
-  ttestDescriptivesTable <- createJaspTable(title = gettext("Descriptives"))
+  ttestDescriptivesTable <- createJaspTable(title = gettext("Descriptives"), dependencies = "descriptives")
   ttestDescriptivesTable$showSpecifiedColumnsOnly <- TRUE
   ttestDescriptivesTable$position <- 4
   ttestDescriptivesTable$addColumnInfo(name = "v",    type = "string",  title = "")
@@ -471,7 +471,7 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
   container <- jaspResults[["ttestDescriptives"]]
 
   if (is.null(container[["plotsRainCloud"]])) {
-    subcontainer <- createJaspContainer(gettext("Raincloud Plots"))
+    subcontainer <- createJaspContainer(gettext("Raincloud Plots"), dependencies = "descriptivesPlotsRainCloud")
     subcontainer$position <- 6
     container[["plotsRainCloud"]] <- subcontainer
   } else {

--- a/R/ttestpairedsamples.R
+++ b/R/ttestpairedsamples.R
@@ -392,6 +392,7 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
   if (is.null(container[["plots"]])) {
     subcontainer <- createJaspContainer(gettext("Descriptives Plots"), dependencies = c("descriptivesPlots", "descriptivesPlotsConfidenceInterval"))
     subcontainer$position <- 5
+    container[["plots"]] <- subcontainer
   } else {
     subcontainer <- container[["plots"]]
   }


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1522

For some reason, the containers of the descriptives plots, raincloud plots, and raincloud difference plots were always remade. All dependencies were put on the outermost container, so if you toggled the descriptives table then all the raincloud plots and descriptives plots were remade.