### PR TITLE
Attempt to fix encoding in raincloud plot

### DIFF
--- a/R/commonTTest.R
+++ b/R/commonTTest.R
@@ -572,7 +572,7 @@ summarySEwithin <- function(data=NULL, measurevar, betweenvars=NULL, withinvars=
                                 breaks = yBreaks) +
     ggplot2::scale_x_continuous(name = xLabel,
                                 breaks = xBreaks,
-                                labels = gettext(xLabels)) +
+                                labels = xLabels) +
     ggplot2::scale_fill_brewer(palette = "Dark2") +
     ggplot2::scale_color_brewer(palette = "Dark2")
 


### PR DESCRIPTION
attempt to fix https://github.com/jasp-stats/jasp-test-release/issues/1746

I cannot actually test this, but I noticed that the labels for the x-axis is run through `gettext`, which does not make sense, because the labels are taken from the data. I don't know whether this fixes the issues on Windows, because I don't have Windows. But I guess this makes sense to remove anyway.

Who could test this? @vandenman or @JorisGoosen: you can run Windows, right? 😛 

