### PR TITLE
Descriptives plots now use jaspGraphs

### DIFF
--- a/R/commonbayesianttest.R
+++ b/R/commonbayesianttest.R
@@ -1141,49 +1141,42 @@
                                           groupNames = NULL, CRI = .95,
                                           testValueOpt = NULL, paired = FALSE) {
 
-  # to be remade in jaspGraphs
   hasGrouping <- !is.null(grouping)
   if (hasGrouping) {
 
     summaryStat <- tapply(data[[1L]], data[[2L]], function(x) {
       .posteriorSummaryGroupMean(variable = x, descriptivesPlotsCredibleInterval = CRI)
     })
+
     summaryStat <- do.call(rbind.data.frame, summaryStat)
-    summaryStat$groupingVariable <- factor(groupNames)
-    mapping <- ggplot2::aes(x=groupingVariable, y=median, group=group)
+    summaryStat$groupingVariable <- factor(groupNames, levels = groupNames)
 
   } else {
 
     summaryStat <- as.data.frame(.posteriorSummaryGroupMean(data, descriptivesPlotsCredibleInterval = CRI))
     summaryStat$groupingVariable <- var
-    mapping <- ggplot2::aes(x=groupingVariable, y=median, group=group)
-    testValue <- data.frame("testValue" = testValueOpt) # default zero
 
   }
 
   if (hasGrouping && !paired) {
-    ylab <- ggplot2::ylab(var)
-    xlab <- ggplot2::xlab(grouping)
+    yName <- var
+    xName <- grouping
   } else {
-    ylab <- ggplot2::ylab(NULL)
-    xlab <- ggplot2::xlab(NULL)
+    xName <- yName <- NULL
   }
 
-  summaryStat$group <- 1
-
-  pd <- ggplot2::position_dodge(.2)
-
-  p <-  jaspGraphs::themeJasp(ggplot2::ggplot(summaryStat, mapping = mapping) +
-      ggplot2::geom_errorbar(ggplot2::aes(ymin=ciLower, ymax=ciUpper), colour="black", width=.2, position=pd) +
-      ggplot2::geom_line(position=pd, size = .7) +
-      ggplot2::geom_point(position=pd, size=4) +
-      xlab + ylab) +
-      jaspGraphs::themeJaspRaw() +
-      .base_breaks_y2(summaryStat, testValueOpt) +
-      .base_breaks_x(summaryStat$groupingVariable)
-
-  if (!is.null(testValueOpt))
-    p <- p + ggplot2::geom_hline(data = testValue, ggplot2::aes(yintercept=testValue), linetype="dashed")
+  p <- jaspGraphs::descriptivesPlot(
+    x                      = summaryStat[["groupingVariable"]],
+    y                      = summaryStat[["median"]],
+    ciLower                = summaryStat[["ciLower"]],
+    ciUpper                = summaryStat[["ciUpper"]],
+    group                  = summaryStat[["group"]],
+    xName                  = xName,
+    yName                  = yName,
+    noXLevelNames          = FALSE,
+    horizontalLine         = testValueOpt,
+    horizontalLineLineType = "dashed"
+  )
 
   return(p)
 

--- a/R/commonbayesianttest.R
+++ b/R/commonbayesianttest.R
@@ -1176,7 +1176,7 @@
     noXLevelNames          = FALSE,
     horizontalLine         = testValueOpt,
     horizontalLineLineType = "dashed"
-  )
+  ) + jaspGraphs::themeJaspRaw(axis.title.cex = jaspGraphs::getGraphOption("axis.title.cex"))
 
   return(p)
 

--- a/R/ttestindependentsamples.R
+++ b/R/ttestindependentsamples.R
@@ -605,8 +605,8 @@ ttestIndependentMainTableRow <- function(variable, dataset, test, testStat, effS
 }
 
 .ttestIndependentDescriptivesPlotFill <- function(dataset, options, variable) {
-  groups   <- options$groupingVariable
 
+  groups <- options$groupingVariable
   errors <- .hasErrors(dataset,
                        message = 'short',
                        type = c('observations', 'variance', 'infinity'),
@@ -614,50 +614,32 @@ ttestIndependentMainTableRow <- function(variable, dataset, test, testStat, effS
                        observations.amount = '< 2',
                        observations.grouping = groups)
 
-  if(!identical(errors, FALSE))
+  if (!isFALSE(errors))
     stop(errors$message)
 
-  descriptivesPlotList <- list()
-
-  base_breaks_x <- function(x) {
-    b <- unique(as.numeric(x))
-    d <- data.frame(y = -Inf, yend = -Inf, x = min(b), xend = max(b))
-    list(ggplot2::geom_segment(data = d, ggplot2::aes(x = x, y = y, xend = xend,
-                                                      yend = yend), inherit.aes = FALSE, size = 1))
-  }
-
-  base_breaks_y <- function(x) {
-    ci.pos <- c(x[, "dependent"] - x[, "ci"], x[, "dependent"] + x[, "ci"])
-    b <- pretty(ci.pos)
-    d <- data.frame(x = -Inf, xend = -Inf, y = min(b), yend = max(b))
-    list(ggplot2::geom_segment(data = d, ggplot2::aes(x = x, y = y,xend = xend,
-                                                      yend = yend), inherit.aes = FALSE, size = 1),
-         ggplot2::scale_y_continuous(breaks = c(min(b), max(b))))
-  }
-
   dataset <- na.omit(dataset[, c(groups, variable)])
-  ci <- options$descriptivesPlotsConfidenceInterval
-  summaryStat <- summarySE(as.data.frame(dataset),
-                           measurevar = variable,
-                           groupvars = groups,
-                           conf.interval = ci, na.rm = TRUE, .drop = FALSE)
+  summaryStat <- summarySE(
+    dataset,
+    measurevar    = variable,
+    groupvars     = groups,
+    conf.interval = options[["descriptivesPlotsConfidenceInterval"]],
+    na.rm         = TRUE,
+    .drop         = FALSE
+  )
 
   colnames(summaryStat)[which(colnames(summaryStat) == variable)] <- "dependent"
   colnames(summaryStat)[which(colnames(summaryStat) == groups)]   <- "groupingVariable"
 
-  pd <- ggplot2::position_dodge(0.2)
-
-  p <- ggplot2::ggplot(summaryStat, ggplot2::aes(x = groupingVariable,
-                                                 y = dependent, group = 1)) +
-    ggplot2::geom_errorbar(ggplot2::aes(ymin = ciLower, ymax = ciUpper),
-                           colour = "black", width = 0.2, position = pd) +
-    ggplot2::geom_line(position = pd, size = 0.7) +
-    ggplot2::geom_point(position = pd, size = 4) +
-    ggplot2::ylab(unlist(variable)) +
-    ggplot2::xlab(options$groupingVariable) +
-    base_breaks_y(summaryStat) + base_breaks_x(summaryStat$groupingVariable)
-
-  p <- jaspGraphs::themeJasp(p)
+  p <- jaspGraphs::descriptivesPlot(
+    x                      = summaryStat[["groupingVariable"]],
+    y                      = summaryStat[["dependent"]],
+    ciLower                = summaryStat[["ciLower"]],
+    ciUpper                = summaryStat[["ciUpper"]],
+    group                  = summaryStat[["group"]],
+    noXLevelNames          = FALSE,
+    yName                  = variable,
+    xName                  = groups
+  ) + jaspGraphs::themeJaspRaw(axis.title.cex = jaspGraphs::getGraphOption("axis.title.cex"))
 
   return(p)
 }

--- a/R/ttestonesample.R
+++ b/R/ttestonesample.R
@@ -405,41 +405,33 @@ TTestOneSample <- function(jaspResults, dataset = NULL, options, ...) {
                        type = c('observations', 'variance', 'infinity'),
                        all.target = variable,
                        observations.amount = c('< 2'))
-  if(!identical(errors, FALSE))
+  if (!isFALSE(errors))
     stop(errors$message)
 
+  dataSubset <- data.frame(
+    dependent        = dataset[[variable]],
+    groupingVariable = rep(variable, nrow(dataset))
+  )
 
-  base_breaks_y <- function(x, options) {
+  summaryStat <- summarySE(
+    dataSubset,
+    measurevar    = "dependent",
+    groupvars     = "groupingVariable",
+    conf.interval = options[["descriptivesPlotsConfidenceInterval"]],
+    na.rm         = TRUE,
+    .drop         = FALSE
+  )
 
-    values <- c(options$testValue, x[, "dependent"] - x[, "ci"],
-                x[, "dependent"] + x[, "ci"])
-    ci.pos <- c(min(values), max(values))
-    b <- pretty(ci.pos)
-    d <- data.frame(x = -Inf, xend = -Inf, y = min(b), yend = max(b))
-    list(ggplot2::geom_segment(data = d, ggplot2::aes(x = x, y = y, xend = xend,
-                                                      yend = yend), inherit.aes = FALSE, size = 1),
-         ggplot2::scale_y_continuous(breaks = c(min(b),  options$testValue, max(b))))
-  }
-
-  dataSubset <- data.frame(dependent = dataset[[.v(variable)]],
-                           groupingVariable = rep(variable, length(dataset[[.v(variable)]])))
-
-  ci <- options$descriptivesPlotsConfidenceInterval
-  summaryStat <- summarySE(dataSubset, measurevar = "dependent",
-                           groupvars = "groupingVariable",
-                           conf.interval = ci, na.rm = TRUE, .drop = FALSE)
-  testValue <- data.frame(testValue = options$testValue)
-  pd <- ggplot2::position_dodge(0.2)
-  p <- ggplot2::ggplot(summaryStat, ggplot2::aes(x = groupingVariable, y = dependent, group = 1)) +
-    ggplot2::geom_errorbar(ggplot2::aes(ymin = ciLower,  ymax = ciUpper),
-                           colour = "black", width = 0.2, position = pd) +
-    ggplot2::geom_line(position = pd, size = 0.7) +#gives geom_path warning+
-    ggplot2::geom_point(position = pd, size = 4)  +
-    ggplot2::geom_hline(data = testValue, ggplot2::aes(yintercept = testValue), linetype = "dashed") +
-    ggplot2::ylab(NULL) + ggplot2::xlab(NULL) + base_breaks_y(summaryStat, options)
-  p <- jaspGraphs::themeJasp(p) +
-    ggplot2::theme(axis.text.x = ggplot2::element_blank(),
-                   axis.ticks.x = ggplot2::element_blank())
+  p <- jaspGraphs::descriptivesPlot(
+    x                      = summaryStat[["groupingVariable"]],
+    y                      = summaryStat[["dependent"]],
+    ciLower                = summaryStat[["ciLower"]],
+    ciUpper                = summaryStat[["ciUpper"]],
+    group                  = summaryStat[["group"]],
+    noXLevelNames          = FALSE,
+    horizontalLine         = options[["testValue"]],
+    horizontalLineLineType = "dashed"
+  ) + jaspGraphs::themeJaspRaw(axis.title.cex = jaspGraphs::getGraphOption("axis.title.cex"))
 
   return(p)
 }

--- a/tests/testthat/_snaps/ttestbayesianindependentsamples/descriptives.svg
+++ b/tests/testthat/_snaps/ttestbayesianindependentsamples/descriptives.svg
@@ -18,41 +18,41 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<rect x='-0.000000000000064' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
 </g>
 <defs>
-  <clipPath id='cpNzQuOTR8NzIwLjAwfDIwLjcxfDUxMC4xNA=='>
-    <rect x='74.94' y='20.71' width='645.06' height='489.43' />
+  <clipPath id='cpNzcuOTl8NzIwLjAwfDIwLjcxfDUwNy4wOQ=='>
+    <rect x='77.99' y='20.71' width='642.01' height='486.39' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNzQuOTR8NzIwLjAwfDIwLjcxfDUxMC4xNA==)'>
-<rect x='74.94' y='20.71' width='645.06' height='489.43' style='stroke-width: 10.67; stroke: none;' />
-<polyline points='221.55,85.98 280.19,85.98 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='250.87,85.98 250.87,356.03 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='221.55,356.03 280.19,356.03 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='514.76,168.22 573.40,168.22 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='544.08,168.22 544.08,455.51 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='514.76,455.51 573.40,455.51 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='250.87,221.01 544.08,311.86 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
-<circle cx='250.87' cy='221.01' r='4.62' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='544.08' cy='311.86' r='4.62' style='stroke-width: 0.71; fill: #000000;' />
-<line x1='250.55' y1='510.14' x2='544.39' y2='510.14' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<line x1='74.94' y1='488.21' x2='74.94' y2='42.64' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<rect x='74.94' y='20.71' width='645.06' height='489.43' style='stroke-width: 0.00; stroke: none;' />
+<g clip-path='url(#cpNzcuOTl8NzIwLjAwfDIwLjcxfDUwNy4wOQ==)'>
+<rect x='77.99' y='20.71' width='642.01' height='486.39' style='stroke-width: 10.67; stroke: none;' />
+<polyline points='223.90,85.58 282.27,85.58 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='253.08,85.58 253.08,353.94 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='223.90,353.94 282.27,353.94 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='515.72,167.30 574.09,167.30 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='544.91,167.30 544.91,452.80 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='515.72,452.80 574.09,452.80 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='253.08,219.76 544.91,310.05 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
+<circle cx='253.08' cy='219.76' r='4.62' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='544.91' cy='310.05' r='4.62' style='stroke-width: 0.71; fill: #000000;' />
+<line x1='252.77' y1='507.09' x2='545.23' y2='507.09' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<line x1='77.99' y1='485.30' x2='77.99' y2='42.50' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<rect x='77.99' y='20.71' width='642.01' height='486.39' style='stroke-width: 0.00; stroke: none;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='74.94,510.14 74.94,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
-<text x='59.47' y='493.74' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='29.29px' lengthAdjust='spacingAndGlyphs'>-0.6</text>
-<text x='59.47' y='48.80' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='23.63px' lengthAdjust='spacingAndGlyphs'>0.2</text>
-<polyline points='66.44,487.89 74.94,487.89 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='66.44,42.95 74.94,42.95 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='74.94,510.14 720.00,510.14 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
-<polyline points='250.87,518.64 250.87,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='544.08,518.64 544.08,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<text x='250.87' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='544.08' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='397.47' y='567.49' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='80.34px' lengthAdjust='spacingAndGlyphs'>contBinom</text>
-<text transform='translate(16.68,265.42) rotate(-90)' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='86.93px' lengthAdjust='spacingAndGlyphs'>contNormal</text>
-<text x='397.47' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='89.78px' lengthAdjust='spacingAndGlyphs'>descriptives</text>
+<polyline points='77.99,507.09 77.99,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<text x='62.51' y='490.84' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='29.29px' lengthAdjust='spacingAndGlyphs'>-0.6</text>
+<text x='62.51' y='48.67' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='23.63px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<polyline points='69.49,484.99 77.99,484.99 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='69.49,42.82 77.99,42.82 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='77.99,507.09 720.00,507.09 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<polyline points='253.08,515.60 253.08,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='544.91,515.60 544.91,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<text x='253.08' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='544.91' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='399.00' y='566.78' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='96.40px' lengthAdjust='spacingAndGlyphs'>contBinom</text>
+<text transform='translate(19.02,263.90) rotate(-90)' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='104.32px' lengthAdjust='spacingAndGlyphs'>contNormal</text>
+<text x='399.00' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='89.78px' lengthAdjust='spacingAndGlyphs'>descriptives</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/ttestbayesianindependentsamples/descriptives.svg
+++ b/tests/testthat/_snaps/ttestbayesianindependentsamples/descriptives.svg
@@ -38,8 +38,6 @@
 <circle cx='544.08' cy='311.86' r='4.62' style='stroke-width: 0.71; fill: #000000;' />
 <line x1='250.55' y1='510.14' x2='544.39' y2='510.14' style='stroke-width: 0.64; stroke-linecap: butt;' />
 <line x1='74.94' y1='488.21' x2='74.94' y2='42.64' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<line x1='74.94' y1='487.89' x2='74.94' y2='42.95' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='250.87' y1='510.14' x2='544.08' y2='510.14' style='stroke-width: 2.13; stroke-linecap: butt;' />
 <rect x='74.94' y='20.71' width='645.06' height='489.43' style='stroke-width: 0.00; stroke: none;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>

--- a/tests/testthat/_snaps/ttestbayesianonesample/descriptives.svg
+++ b/tests/testthat/_snaps/ttestbayesianonesample/descriptives.svg
@@ -31,17 +31,16 @@
 <polyline points='382.39,60.06 382.39,479.11 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
 <polyline points='326.12,479.11 438.66,479.11 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
 <circle cx='382.39' cy='269.59' r='4.62' style='stroke-width: 0.71; fill: #000000;' />
+<line x1='44.77' y1='44.55' x2='720.00' y2='44.55' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
 <line x1='382.07' y1='545.29' x2='382.70' y2='545.29' style='stroke-width: 0.64; stroke-linecap: butt;' />
 <line x1='44.77' y1='521.77' x2='44.77' y2='44.23' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<line x1='44.77' y1='521.45' x2='44.77' y2='44.55' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='44.77' y1='44.55' x2='720.00' y2='44.55' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
 <rect x='44.77' y='20.71' width='675.23' height='524.59' style='stroke-width: 0.00; stroke: none;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <polyline points='44.77,545.29 44.77,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
 <text x='29.29' y='527.30' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='29.29px' lengthAdjust='spacingAndGlyphs'>-0.4</text>
-<text x='29.29' y='50.40' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='23.63px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text x='29.29' y='50.40' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='23.63px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='29.29' y='50.40' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='29.29' y='50.40' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
 <polyline points='36.27,521.45 44.77,521.45 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
 <polyline points='36.27,44.55 44.77,44.55 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
 <polyline points='36.27,44.55 44.77,44.55 ' style='stroke-width: 0.64; stroke-linecap: butt;' />

--- a/tests/testthat/_snaps/ttestbayesianpairedsamples/descriptives.svg
+++ b/tests/testthat/_snaps/ttestbayesianpairedsamples/descriptives.svg
@@ -27,19 +27,17 @@
 </defs>
 <g clip-path='url(#cpNDQuNzd8NzIwLjAwfDIwLjcxfDU0NS4yOQ==)'>
 <rect x='44.77' y='20.71' width='675.23' height='524.59' style='stroke-width: 10.67; stroke: none;' />
-<polyline points='505.15,444.03 566.54,444.03 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='535.85,444.03 535.85,499.91 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='505.15,499.91 566.54,499.91 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='198.23,78.35 259.62,78.35 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='228.93,78.35 228.93,159.24 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='198.23,159.24 259.62,159.24 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='228.93,118.80 535.85,471.97 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
-<circle cx='535.85' cy='471.97' r='4.62' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='228.93' cy='118.80' r='4.62' style='stroke-width: 0.71; fill: #000000;' />
+<polyline points='198.23,444.03 259.62,444.03 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='228.93,444.03 228.93,499.91 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='198.23,499.91 259.62,499.91 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='505.15,78.35 566.54,78.35 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='535.85,78.35 535.85,159.24 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='505.15,159.24 566.54,159.24 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='228.93,471.97 535.85,118.80 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
+<circle cx='228.93' cy='471.97' r='4.62' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='535.85' cy='118.80' r='4.62' style='stroke-width: 0.71; fill: #000000;' />
 <line x1='228.61' y1='545.29' x2='536.17' y2='545.29' style='stroke-width: 0.64; stroke-linecap: butt;' />
 <line x1='44.77' y1='521.77' x2='44.77' y2='44.23' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<line x1='44.77' y1='521.45' x2='44.77' y2='44.55' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='228.93' y1='545.29' x2='535.85' y2='545.29' style='stroke-width: 2.13; stroke-linecap: butt;' />
 <rect x='44.77' y='20.71' width='675.23' height='524.59' style='stroke-width: 0.00; stroke: none;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
@@ -51,8 +49,8 @@
 <polyline points='44.77,545.29 720.00,545.29 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
 <polyline points='228.93,553.80 228.93,545.29 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
 <polyline points='535.85,553.80 535.85,545.29 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<text x='228.93' y='572.47' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='92.62px' lengthAdjust='spacingAndGlyphs'>contGamma</text>
-<text x='535.85' y='572.47' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='86.93px' lengthAdjust='spacingAndGlyphs'>contNormal</text>
+<text x='228.93' y='572.47' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='86.93px' lengthAdjust='spacingAndGlyphs'>contNormal</text>
+<text x='535.85' y='572.47' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='92.62px' lengthAdjust='spacingAndGlyphs'>contGamma</text>
 <text x='382.39' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='89.78px' lengthAdjust='spacingAndGlyphs'>descriptives</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/ttestindependentsamples/descriptives.svg
+++ b/tests/testthat/_snaps/ttestindependentsamples/descriptives.svg
@@ -36,8 +36,6 @@
 <polyline points='253.08,219.76 544.91,310.05 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
 <circle cx='253.08' cy='219.76' r='4.62' style='stroke-width: 0.71; fill: #000000;' />
 <circle cx='544.91' cy='310.05' r='4.62' style='stroke-width: 0.71; fill: #000000;' />
-<line x1='77.99' y1='484.99' x2='77.99' y2='42.82' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='253.08' y1='507.09' x2='544.91' y2='507.09' style='stroke-width: 2.13; stroke-linecap: butt;' />
 <line x1='252.77' y1='507.09' x2='545.23' y2='507.09' style='stroke-width: 0.64; stroke-linecap: butt;' />
 <line x1='77.99' y1='485.30' x2='77.99' y2='42.50' style='stroke-width: 0.64; stroke-linecap: butt;' />
 <rect x='77.99' y='20.71' width='642.01' height='486.39' style='stroke-width: 0.00; stroke: none;' />

--- a/tests/testthat/_snaps/ttestindependentsamples/mischief-descriptives-plot.svg
+++ b/tests/testthat/_snaps/ttestindependentsamples/mischief-descriptives-plot.svg
@@ -36,8 +36,6 @@
 <polyline points='238.66,330.23 539.50,219.68 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
 <circle cx='238.66' cy='330.23' r='4.62' style='stroke-width: 0.71; fill: #000000;' />
 <circle cx='539.50' cy='219.68' r='4.62' style='stroke-width: 0.71; fill: #000000;' />
-<line x1='58.15' y1='484.99' x2='58.15' y2='42.82' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='238.66' y1='507.09' x2='539.50' y2='507.09' style='stroke-width: 2.13; stroke-linecap: butt;' />
 <line x1='238.34' y1='507.09' x2='539.81' y2='507.09' style='stroke-width: 0.64; stroke-linecap: butt;' />
 <line x1='58.15' y1='485.30' x2='58.15' y2='42.50' style='stroke-width: 0.64; stroke-linecap: butt;' />
 <rect x='58.15' y='20.71' width='661.85' height='486.39' style='stroke-width: 0.00; stroke: none;' />

--- a/tests/testthat/_snaps/ttestonesample/descriptives.svg
+++ b/tests/testthat/_snaps/ttestonesample/descriptives.svg
@@ -21,31 +21,32 @@
 <rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
 </g>
 <defs>
-  <clipPath id='cpMzkuMTF8NzIwLjAwfDIwLjcxfDU2Ny41MA=='>
-    <rect x='39.11' y='20.71' width='680.89' height='546.79' />
+  <clipPath id='cpMzkuMTF8NzIwLjAwfDIwLjcxfDU0NS4yOQ=='>
+    <rect x='39.11' y='20.71' width='680.89' height='524.59' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzkuMTF8NzIwLjAwfDIwLjcxfDU2Ny41MA==)'>
-<rect x='39.11' y='20.71' width='680.89' height='546.79' style='stroke-width: 10.67; stroke: none;' />
-<polyline points='322.81,77.97 436.30,77.97 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='379.56,77.97 379.56,198.88 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='322.81,198.88 436.30,198.88 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<circle cx='379.56' cy='138.42' r='4.62' style='stroke-width: 0.71; fill: #000000;' />
-<line x1='39.11' y1='542.64' x2='720.00' y2='542.64' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
-<line x1='39.11' y1='542.64' x2='39.11' y2='45.56' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='379.24' y1='567.50' x2='379.87' y2='567.50' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<line x1='39.11' y1='542.96' x2='39.11' y2='45.24' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<rect x='39.11' y='20.71' width='680.89' height='546.79' style='stroke-width: 0.00; stroke: none;' />
+<g clip-path='url(#cpMzkuMTF8NzIwLjAwfDIwLjcxfDU0NS4yOQ==)'>
+<rect x='39.11' y='20.71' width='680.89' height='524.59' style='stroke-width: 10.67; stroke: none;' />
+<polyline points='322.81,75.64 436.30,75.64 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='379.56,75.64 379.56,191.65 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='322.81,191.65 436.30,191.65 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<circle cx='379.56' cy='133.64' r='4.62' style='stroke-width: 0.71; fill: #000000;' />
+<line x1='39.11' y1='521.45' x2='720.00' y2='521.45' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
+<line x1='379.24' y1='545.29' x2='379.87' y2='545.29' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<line x1='39.11' y1='521.77' x2='39.11' y2='44.23' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<rect x='39.11' y='20.71' width='680.89' height='524.59' style='stroke-width: 0.00; stroke: none;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='39.11,567.50 39.11,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
-<text x='23.63' y='548.49' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='23.63px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text x='23.63' y='548.49' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='23.63px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text x='23.63' y='51.41' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='23.63px' lengthAdjust='spacingAndGlyphs'>2.5</text>
-<polyline points='30.61,542.64 39.11,542.64 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='30.61,542.64 39.11,542.64 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='30.61,45.56 39.11,45.56 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='39.11,567.50 720.00,567.50 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<polyline points='39.11,545.29 39.11,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<text x='23.63' y='527.30' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='23.63' y='527.30' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='23.63' y='50.40' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='23.63px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<polyline points='30.61,521.45 39.11,521.45 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='30.61,521.45 39.11,521.45 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='30.61,44.55 39.11,44.55 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='39.11,545.29 720.00,545.29 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<polyline points='379.56,553.80 379.56,545.29 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<text x='379.56' y='572.47' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='92.62px' lengthAdjust='spacingAndGlyphs'>contGamma</text>
 <text x='379.56' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='89.78px' lengthAdjust='spacingAndGlyphs'>descriptives</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/ttestpairedsamples/descriptives.svg
+++ b/tests/testthat/_snaps/ttestpairedsamples/descriptives.svg
@@ -27,17 +27,15 @@
 </defs>
 <g clip-path='url(#cpNDQuNzd8NzIwLjAwfDIwLjcxfDU0NS4yOQ==)'>
 <rect x='44.77' y='20.71' width='675.23' height='524.59' style='stroke-width: 10.67; stroke: none;' />
-<polyline points='198.23,429.30 259.62,429.30 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='228.93,429.30 228.93,514.64 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='198.23,514.64 259.62,514.64 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
 <polyline points='505.15,76.12 566.54,76.12 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
 <polyline points='535.85,76.12 535.85,161.47 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
 <polyline points='505.15,161.47 566.54,161.47 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='198.23,429.30 259.62,429.30 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='228.93,429.30 228.93,514.64 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='198.23,514.64 259.62,514.64 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
 <polyline points='228.93,471.97 535.85,118.80 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
-<circle cx='228.93' cy='471.97' r='4.62' style='stroke-width: 0.71; fill: #000000;' />
 <circle cx='535.85' cy='118.80' r='4.62' style='stroke-width: 0.71; fill: #000000;' />
-<line x1='44.77' y1='521.45' x2='44.77' y2='44.55' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='228.93' y1='545.29' x2='535.85' y2='545.29' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<circle cx='228.93' cy='471.97' r='4.62' style='stroke-width: 0.71; fill: #000000;' />
 <line x1='228.61' y1='545.29' x2='536.17' y2='545.29' style='stroke-width: 0.64; stroke-linecap: butt;' />
 <line x1='44.77' y1='521.77' x2='44.77' y2='44.23' style='stroke-width: 0.64; stroke-linecap: butt;' />
 <rect x='44.77' y='20.71' width='675.23' height='524.59' style='stroke-width: 0.00; stroke: none;' />


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1873, the line was thicker at some parts because it still used the deprecated `base_breaks_x` and/ or `base_breaks_y` functions. The difference is also noticeable in the SVG files if you look closely enough. The new plots use the [`descriptivesPlot`](https://jasp-stats.github.io/jaspGraphs/reference/descriptivesPlot.html) function inside jaspGraphs. 

@JohnnyDoorn do you have time to review this?