### PR TITLE
Fix bug in variance assumption table when trying to show an error

### DIFF
--- a/R/ttestindependentsamples.R
+++ b/R/ttestindependentsamples.R
@@ -441,12 +441,10 @@ ttestIndependentMainTableRow <- function(variable, dataset, test, testStat, effS
     }
 
     if (!is.null(errorMessage)) {
-      row[["F"]] <- NaN
-      table$addFootnote(errors$message, colNames = "F", rowNames = variable)
-    }
-
-    if (!result[["LeveneComputed"]])
-      table$addFootnote(gettext("F-statistic could not be calculated"), colNames = "F", rowNames = variable)
+      row[["fStat"]] <- NaN
+      table$addFootnote(errorMessage, colNames = "fStat", rowNames = variable)
+    } else if (!result[["LeveneComputed"]])
+      table$addFootnote(gettext("F-statistic could not be calculated"), colNames = "fStat", rowNames = variable)
 
     table$addRows(row, rowNames = variable)
   }


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1976

I'd request @juliuspf to review, but I think he can't install developer modules.

New results look like this:

![image](https://user-images.githubusercontent.com/21319932/191022402-578d39ee-8842-44b5-9d64-b6cde00a30d9.png)

See the test issue for the jasp file that produces the error.

I additionally changed `"F"` to `"fStat"` because that is the column is called, https://github.com/jasp-stats/jaspTTests/blob/b49bcd34d13fe0ebbfc48c41ab426dfb2b23b6c1/R/ttestindependentsamples.R#L205