### PR TITLE
Fix failing unicode test

### DIFF
--- a/tests/testthat/_snaps/ttestindependentsamples/mischief-descriptives-plot.svg
+++ b/tests/testthat/_snaps/ttestindependentsamples/mischief-descriptives-plot.svg
@@ -51,8 +51,8 @@
 <polyline points='58.15,507.09 720.00,507.09 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
 <polyline points='238.66,515.60 238.66,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
 <polyline points='539.50,515.60 539.50,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<text x='238.66' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='246.32px' lengthAdjust='spacingAndGlyphs'>&lt;U+672A&gt;&lt;U+9009&gt;&lt;U+4E2D&gt;</text>
-<text x='539.50' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='164.53px' lengthAdjust='spacingAndGlyphs'>&lt;U+9009&gt;&lt;U+4E2D&gt;</text>
+<text x='238.66' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='38.25px' lengthAdjust='spacingAndGlyphs'>未选中</text>
+<text x='539.50' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='25.50px' lengthAdjust='spacingAndGlyphs'>选中</text>
 <text x='389.08' y='566.78' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='52.17px' lengthAdjust='spacingAndGlyphs'>Cloak</text>
 <text transform='translate(19.02,263.90) rotate(-90)' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='74.84px' lengthAdjust='spacingAndGlyphs'>Mischief</text>
 <text x='389.08' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='193.70px' lengthAdjust='spacingAndGlyphs'>mischief-Descriptives-plot</text>

--- a/tests/testthat/_snaps/ttestindependentsamples/mischief-raincloud-plot.svg
+++ b/tests/testthat/_snaps/ttestindependentsamples/mischief-raincloud-plot.svg
@@ -94,8 +94,8 @@
 <polyline points='67.61,507.09 720.00,507.09 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
 <polyline points='115.27,515.60 115.27,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
 <polyline points='320.77,515.60 320.77,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<text x='115.27' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='246.32px' lengthAdjust='spacingAndGlyphs'>&lt;U+672A&gt;&lt;U+9009&gt;&lt;U+4E2D&gt;</text>
-<text x='320.77' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='164.53px' lengthAdjust='spacingAndGlyphs'>&lt;U+9009&gt;&lt;U+4E2D&gt;</text>
+<text x='115.27' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='38.25px' lengthAdjust='spacingAndGlyphs'>未选中</text>
+<text x='320.77' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='25.50px' lengthAdjust='spacingAndGlyphs'>选中</text>
 <text x='393.80' y='566.78' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='52.17px' lengthAdjust='spacingAndGlyphs'>Cloak</text>
 <text transform='translate(19.02,263.90) rotate(-90)' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='74.84px' lengthAdjust='spacingAndGlyphs'>Mischief</text>
 <text x='393.80' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='170.09px' lengthAdjust='spacingAndGlyphs'>mischief-raincloud-plot</text>

--- a/tests/testthat/test-ttestindependentsamples.R
+++ b/tests/testthat/test-ttestindependentsamples.R
@@ -156,7 +156,7 @@ test_that("Analysis works with unicode", {
   set.seed(1)
   dataset <- structure(list(Participant = 1:24,
                             Cloak = structure(c(1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L),
-                                              .Label = c("<U+672A><U+9009><U+4E2D>", "<U+9009><U+4E2D>"), class = "factor"),
+                                              .Label = c("\U672A\U9009\U4E2D", "\U9009\U4E2D"), class = "factor"),
                             Mischief = c(3L, 1L, 5L, 4L, 6L, 4L, 6L, 2L, 0L, 5L, 4L, 5L, 4L, 3L, 6L, 6L, 8L, 5L, 5L, 4L, 2L, 5L, 7L, 5L)),
                        row.names = c(NA, -24L), class = "data.frame")
 
@@ -199,9 +199,9 @@ test_that("Analysis works with unicode", {
 
   table <- results[["results"]][["ttestDescriptives"]][["collection"]][["ttestDescriptives_table"]][["data"]]
   jaspTools::expect_equal_tables(table,
-    list("TRUE", 12, 0.51010001000002, "&lt;U+672A&gt;&lt;U+9009&gt;&lt;U+4E2D>",
-         3.75, 1.91287503750007, 0.552199458913392, "Mischief", "FALSE",
-         12, 0.330289129537908, "&lt;U+9009&gt;&lt;U+4E2D>", 5, 1.65144564768954,
+    list("TRUE", 12, 0.51010001000002, "<unicode><unicode><unicode>", 3.75,
+         1.91287503750007, 0.552199458913392, "Mischief", "FALSE", 12,
+         0.330289129537908, "<unicode><unicode>", 5, 1.65144564768954,
          0.476731294622796, "Mischief"),
     label = "Group Descriptives table results match"
   )


### PR DESCRIPTION
https://github.com/jasp-stats/jaspColumnEncoder/pull/7 caused the unit tests to fail. But the problem was more that the unit tests weren't actually testing Unicode... `<U+672A>` and so forth should have been `\U672A`...