### PR TITLE
paired raincloud plots handle missing data properly

### DIFF
--- a/R/commonbayesianttest.R
+++ b/R/commonbayesianttest.R
@@ -2359,6 +2359,9 @@
       }
       groups  <- rep(pair, each = nrow(dataset))
       subData <- data.frame(dependent = unlist(dataset[, .v(pair)]), groups = groups)
+      missingIndex <- tapply(subData[["dependent"]], subData[["groups"]], is.na) # apply listwise deletion
+      missingIndex <- apply(do.call(cbind, missingIndex), 1, any)
+      subData <- subData[rep(!missingIndex, 2), ]
       p <- try(.descriptivesPlotsRainCloudFill(subData, "dependent", "groups", "", "", addLines = TRUE, horiz = FALSE, NULL))
       if(isTryError(p))
         descriptivesPlotRainCloud$setError(.extractErrorMessage(p))

--- a/R/ttestpairedsamples.R
+++ b/R/ttestpairedsamples.R
@@ -588,6 +588,9 @@ TTestPairedSamplesInternal <- function(jaspResults, dataset = NULL, options, ...
       }
       groups  <- rep(pair, each = nrow(dataset))
       subData <- data.frame(dependent = unlist(dataset[, pair]), groups = groups)
+      missingIndex <- tapply(subData[["dependent"]], subData[["groups"]], is.na) # apply listwise deletion
+      missingIndex <- apply(do.call(cbind, missingIndex), 1, any)
+      subData <- subData[rep(!missingIndex, 2), ]
       p <- try(.descriptivesPlotsRainCloudFill(subData, "dependent", "groups", "", "", addLines = TRUE, horiz = FALSE, NULL))
       if(isTryError(p))
         descriptivesPlotRainCloud$setError(.extractErrorMessage(p))


### PR DESCRIPTION
Now paired raincloud plots handle missingness by listwise (casewise) deletion, which is the only proper way. 
Fix https://github.com/jasp-stats/jasp-issues/issues/2101
