### PR TITLE
no paired argument in indep samples

### DIFF
--- a/R/ttestindependentsamples.R
+++ b/R/ttestindependentsamples.R
@@ -297,7 +297,7 @@ ttestIndependentMainTableRow <- function(variable, dataset, test, testStat, effS
   if (test == "Mann-Whitney") {
     r <- stats::wilcox.test(f, data = dataset,
                             alternative = direction,
-                            conf.int = TRUE, conf.level = ciMeanDiff, paired = FALSE)
+                            conf.int = TRUE, conf.level = ciMeanDiff)
     df   <- ""
     sed  <- ""
     stat <- as.numeric(r$statistic)
@@ -318,7 +318,7 @@ ttestIndependentMainTableRow <- function(variable, dataset, test, testStat, effS
     effectSizeSe <- tanh(rankBisSE)
   } else {
     r <- stats::t.test(f, data = dataset, alternative = direction,
-                       var.equal = test != "Welch", conf.level = ciMeanDiff, paired = FALSE)
+                       var.equal = test != "Welch", conf.level = ciMeanDiff)
 
     df   <- as.numeric(r$parameter)
     m    <- as.numeric(r$estimate[1]) - as.numeric(r$estimate[2])


### PR DESCRIPTION
I think with R 4.4 there is an error when using paired when using the formula setup.. so removed paired = FALSE (which is default anyway).