### PR TITLE
Remove Morey correction from t-tests but keep normalization

### DIFF
--- a/R/commonTTest.R
+++ b/R/commonTTest.R
@@ -399,7 +399,7 @@ gettextf <- function(fmt, ..., domain = NULL)  {
 }
 
 .summarySEwithin <- function(data=NULL, measurevar, betweenvars=NULL, withinvars=NULL, idvar=NULL, na.rm=FALSE,
-                            conf.interval=.95, .drop=TRUE, errorBarType="ci", usePooledSE=FALSE, useMoreyCorrection=TRUE,
+                            conf.interval=.95, .drop=TRUE, errorBarType="ci", usePooledSE=FALSE,
                             dependentName = .BANOVAdependentName,
                             subjectName = .BANOVAsubjectName) {
 
@@ -434,15 +434,14 @@ gettextf <- function(fmt, ..., domain = NULL)  {
       stop("nDistinctObservations got an object of type", paste(class(x), collapse = ", "))
   }
 
-  if (useMoreyCorrection) {
-    # Apply correction from Morey (2008) to the standard error and confidence interval
-    # Get the product of the number of conditions of within-S variables
-    nWithinGroups    <- prod(vapply(ndatac[,withinvars, drop=FALSE], FUN=.nDistinctObservations, FUN.VALUE=numeric(1)))
-    correctionFactor <- sqrt( nWithinGroups / (nWithinGroups-1) )
-    ndatac$sd <- ndatac$sd * correctionFactor
-    ndatac$se <- ndatac$se * correctionFactor
-    ndatac$ci <- ndatac$ci * correctionFactor
-  }
+  # Apply correction from Morey (2008) to the standard error and confidence interval
+  # Get the product of the number of conditions of within-S variables
+  nWithinGroups    <- prod(vapply(ndatac[,withinvars, drop=FALSE], FUN=.nDistinctObservations, FUN.VALUE=numeric(1)))
+  correctionFactor <- sqrt( nWithinGroups / (nWithinGroups-1) )
+  ndatac$sd <- ndatac$sd * correctionFactor
+  ndatac$se <- ndatac$se * correctionFactor
+  ndatac$ci <- ndatac$ci * correctionFactor
+
   
   if (errorBarType == "ci") {
 
@@ -598,8 +597,7 @@ gettextf <- function(fmt, ..., domain = NULL)  {
                                    conf.interval = options[["barPlotCiLevel"]],
                                    na.rm = TRUE,
                                    .drop = FALSE,
-                                   errorBarType = errorType,
-                                   useMoreyCorrection = options[["applyMoreyCorrectionErrorBarsBarplot"]])
+                                   errorBarType = errorType)
   } else {
     data <- data.frame(dependent = dataset[[variable]],
                        group = if (!is.null(groups)) dataset[[groups]] else rep(variable, length(dataset[[variable]])))

--- a/R/ttestpairedsamples.R
+++ b/R/ttestpairedsamples.R
@@ -425,8 +425,7 @@ TTestPairedSamplesInternal <- function(jaspResults, dataset = NULL, options, ...
   if (is.null(container[["plots"]])) {
     subcontainer <- createJaspContainer(gettext("Descriptives Plots"), 
                                         dependencies = c("descriptivesPlot", 
-                                                         "descriptivesPlotCiLevel",
-                                                         "applyMoreyCorrectionErrorBars"))
+                                                         "descriptivesPlotCiLevel"))
     subcontainer$position <- 5
     container[["plots"]] <- subcontainer
   } else {
@@ -472,7 +471,6 @@ TTestPairedSamplesInternal <- function(jaspResults, dataset = NULL, options, ...
                                  
   summaryStat <- .summarySEwithin(data, measurevar = "dependent", withinvars = "group",
                                  idvar = "id", conf.interval =  options[["descriptivesPlotCiLevel"]],
-                                 useMoreyCorrection = options[["applyMoreyCorrectionErrorBars"]],
                                  na.rm = TRUE, .drop = FALSE)
 
   p <- jaspGraphs::descriptivesPlot(
@@ -612,8 +610,7 @@ TTestPairedSamplesInternal <- function(jaspResults, dataset = NULL, options, ...
     subcontainer <- createJaspContainer(gettext("Bar Plots"), dependencies = c("barPlot",
                                                                                "barPlotCiLevel",
                                                                                "barPlotErrorType",
-                                                                               "barPlotYAxisFixedToZero",
-                                                                               "applyMoreyCorrectionErrorBarsBarplot"))
+                                                                               "barPlotYAxisFixedToZero"))
     subcontainer$position <- 8
     container[["barPlots"]] <- subcontainer
   } else {

--- a/inst/qml/TTestPairedSamples.qml
+++ b/inst/qml/TTestPairedSamples.qml
@@ -101,12 +101,6 @@ Form
 		{
 			name: "descriptivesPlot";						label: qsTr("Descriptives plots")
 			CIField { name: "descriptivesPlotCiLevel";	label: qsTr("Confidence interval")						}
-			CheckBox 
-			{ 
-				name: "applyMoreyCorrectionErrorBars"
-				label: qsTr("Normalize error bars")
-				checked:			true
-			}
 		}
 		CheckBox{ name: "raincloudPlot";		label: qsTr("Raincloud plots")									}
 		CheckBox
@@ -117,7 +111,6 @@ Form
 		Common.BarPlots
 		{
 			framework:	form.framework
-			CheckBox	{ name: "applyMoreyCorrectionErrorBarsBarplot";	label: qsTr("Normalize error bars"); checked: true}
 		}
 	}
 


### PR DESCRIPTION
Normalization of the se's should always happen in paired t-test (since it's always about within subjects), so only RM ANOVA should contain the option to normalize, and this option should be about the normalization and not the small Morey component of the normalization. Also makes interface less cluttered.