### PR TITLE
changes for data reading

### DIFF
--- a/R/commonTTest.R
+++ b/R/commonTTest.R
@@ -43,8 +43,8 @@ gettextf <- function(fmt, ..., domain = NULL)  {
       p2 <- pair[[2]]
       if(is.null(p1) || is.null(p2))
         return()
-      datasetErrorCheck <- data.frame(dataset[[.v(p1)]] - dataset[[.v(p2)]])
-      colnames(datasetErrorCheck) <- .v(paste0("Difference between ", p1, " and ", p2))
+      datasetErrorCheck <- data.frame(dataset[[p1]] - dataset[[p2]])
+      colnames(datasetErrorCheck) <- paste0("Difference between ", p1, " and ", p2)
       .hasErrors(datasetErrorCheck,
                  type = "variance",
                  exitAnalysisIfErrors = TRUE)

--- a/R/commonTTest.R
+++ b/R/commonTTest.R
@@ -27,8 +27,17 @@ gettextf <- function(fmt, ..., domain = NULL)  {
 
 .ttestReadData <- function(dataset, options, type) {
 
-  if (options[["naAction"]] == "listwise")
-    return(jaspBase::excludeNaListwise(dataset, options[["dependent"]]))
+  if (options[["naAction"]] == "listwise") {
+
+    if (type %in% c("one-sample", "independent"))
+      exclude <- unlist(options[["dependent"]])
+    else if (type == "paired") {
+      exclude <- unlist(options[["pairs"]])
+      exclude <- exclude[exclude != ""]
+    }
+
+    return(jaspBase::excludeNaListwise(dataset, exclude))
+  }
 
   return(dataset)
 

--- a/R/commonTTest.R
+++ b/R/commonTTest.R
@@ -26,25 +26,12 @@ gettextf <- function(fmt, ..., domain = NULL)  {
 }
 
 .ttestReadData <- function(dataset, options, type) {
-  if (!is.null(dataset))
-    return(dataset)
-  else {
-    groups  <- options$group
-    if (!is.null(groups) && groups == "")
-      groups <- NULL
-    if(type %in% c("one-sample", "independent"))
-      depvars <- unlist(options$dependent)
-    else if (type == 'paired') {
-      depvars <- unlist(options$pairs)
-      depvars <- depvars[depvars != ""]
-    }
-    exclude <- NULL
-    if (options$naAction == "listwise")
-      exclude <- depvars
-    return(.readDataSetToEnd(columns.as.numeric  = depvars,
-                             columns.as.factor   = groups,
-                             exclude.na.listwise = exclude))
-  }
+
+  if (options[["naAction"]] == "listwise")
+    return(jaspBase::excludeNaListwise(dataset, options[["dependent"]]))
+
+  return(dataset)
+
 }
 
 .ttestCheckErrors <- function(dataset, options, type) {
@@ -442,7 +429,7 @@ gettextf <- function(fmt, ..., domain = NULL)  {
   ndatac$se <- ndatac$se * correctionFactor
   ndatac$ci <- ndatac$ci * correctionFactor
 
-  
+
   if (errorBarType == "ci") {
 
     ndatac$ciLower <- datac[,measurevar] - ndatac[,"ci"]
@@ -647,14 +634,14 @@ gettextf <- function(fmt, ..., domain = NULL)  {
 
 
 .ttestQQPlot <- function(jaspResults, dataset, options, ready, type) {
-  
+
   .ttestAssumptionCheckContainer(jaspResults, options, type)
   container <- jaspResults[["AssumptionChecks"]]
   if (!options$qqPlot || !is.null(container[["ttestQQPlot"]]) || !ready)
     return()
-  
+
   container[["QQPlots"]] <- createJaspContainer(gettext("Q-Q Plots"))
-  if (type == "independent") { 
+  if (type == "independent") {
     for (thisVar in options$dependent) {
       groupMeans <- tapply(dataset[[thisVar]], dataset[[options[["group"]]]], mean)
       resid <- dataset[[thisVar]] - groupMeans[dataset[[options[["group"]]]]]
@@ -663,8 +650,8 @@ gettextf <- function(fmt, ..., domain = NULL)  {
       container[["QQPlots"]][[thisVar]] <- qqPlot
       qqPlot$plotObject <- jaspGraphs::plotQQnorm(scale(resid),
                                                   yName = "Standardized residuals",
-                                                  ablineColor = "darkred", 
-                                                  ablineOrigin = TRUE, 
+                                                  ablineColor = "darkred",
+                                                  ablineOrigin = TRUE,
                                                   identicalAxes = TRUE)
     }
   } else if (type == "paired") {
@@ -676,8 +663,8 @@ gettextf <- function(fmt, ..., domain = NULL)  {
       container[["QQPlots"]][[title]] <- qqPlot
       qqPlot$plotObject <- jaspGraphs::plotQQnorm(scale(resid),
                                                   yName = "Standardized residuals",
-                                                  ablineColor = "darkred", 
-                                                  ablineOrigin = TRUE, 
+                                                  ablineColor = "darkred",
+                                                  ablineOrigin = TRUE,
                                                   identicalAxes = TRUE)
     }
   } else if (type == "one-sample") {
@@ -688,8 +675,8 @@ gettextf <- function(fmt, ..., domain = NULL)  {
       container[["QQPlots"]][[thisVar]] <- qqPlot
       qqPlot$plotObject <- jaspGraphs::plotQQnorm(scale(resid),
                                                   yName = "Standardized residuals",
-                                                  ablineColor = "darkred", 
-                                                  ablineOrigin = TRUE, 
+                                                  ablineColor = "darkred",
+                                                  ablineOrigin = TRUE,
                                                   identicalAxes = TRUE)
     }
   }

--- a/R/commonbayesianttest.R
+++ b/R/commonbayesianttest.R
@@ -610,9 +610,9 @@
   } else {
     if (hasGrouping) {
 
-      levels <- levels(dataset[[ .v(grouping) ]])
+      levels <- levels(dataset[[grouping]])
       nlevels <- length(levels)
-      groupingData <- dataset[[.v(grouping)]]
+      groupingData <- dataset[[grouping]]
     } else {
       levels <- NULL
       nlevels <- 1
@@ -626,9 +626,9 @@
 
           if (hasGrouping) {
             level <- levels[i]
-            groupData <- dataset[groupingData == level, .v(var)]
+            groupData <- dataset[groupingData == level, var]
           } else {
-            groupData <- dataset[[.v(var)]]
+            groupData <- dataset[[var]]
           }
           groupDataOm <- groupData[!is.na(groupData)]
 
@@ -693,8 +693,8 @@
   paired <- !is.null(pairs)
 
   if (hasGrouping) {
-    groupingData <- dataset[[.v(grouping)]]
-    levels   <- base::levels(dataset[[.v(grouping)]])
+    groupingData <- dataset[[grouping]]
+    levels   <- base::levels(dataset[[grouping]])
     canDoDescriptives <- length(dependents) >= 1 && !(is.null(grouping) || grouping == "")
   } else if (paired) {
     grouping <- "group"
@@ -716,7 +716,7 @@
             pair <- pairs[[var]]
             levels <- c(pair[[1]], pair[[2]])
 
-            dat <- c(dataset[[.v(pair[[1]])]], dataset[[.v(pair[[2]])]])
+            dat <- c(dataset[[pair[[1]]]], dataset[[pair[[2]]]])
             dat <- data.frame(
               value = dat,
               group = groupingData
@@ -724,8 +724,8 @@
             dat <- dat[!is.na(dat[[1]]), ]
 
           } else {
-            idxC <- !is.na(dataset[[.v(var)]])
-            dat <- dataset[idxC, .v(c(var, grouping))]
+            idxC <- !is.na(dataset[[var]])
+            dat <- dataset[idxC, c(var, grouping)]
           }
 
           obj <- try(.ttestBayesianPlotKGroupMeans(
@@ -1045,11 +1045,11 @@
                                          options, ...) {
   hasGrouping <- !is.null(grouping)
   if (hasGrouping) {
-    levels <- levels(dataset[[.v(grouping)]])
+    levels <- levels(dataset[[grouping]])
     g1 <- levels[1]
     g2 <- levels[2]
-    idxG1 <- dataset[[.v(grouping)]] == g1
-    idxG2 <- dataset[[.v(grouping)]] == g2
+    idxG1 <- dataset[[grouping]] == g1
+    idxG2 <- dataset[[grouping]] == g2
   } else {
     g1 <- NULL
     g2 <- NULL
@@ -1068,18 +1068,18 @@
 
         if (paired) {
           pair <- pairs[[var]]
-          group1 <- dataset[, .v(pair[[1]])]
-          group2 <- dataset[, .v(pair[[2]])]
+          group1 <- dataset[, pair[[1]]]
+          group2 <- dataset[, pair[[2]]]
           idxC <- !(is.na(group1) | is.na(group2))
           group1 <- group1[idxC]
           group2 <- group2[idxC]
         } else {
-          idxC <- !is.na(dataset[[.v(var)]])
+          idxC <- !is.na(dataset[[var]])
           if (hasGrouping) {
-            group1 <- dataset[idxG1 & idxC, .v(var)]
-            group2 <- dataset[idxG2 & idxC, .v(var)]
+            group1 <- dataset[idxG1 & idxC, var]
+            group2 <- dataset[idxG2 & idxC, var]
           } else {
-            group1 <- dataset[idxC, .v(var)]
+            group1 <- dataset[idxC, var]
             group1 <- group1 - options[["testValue"]]
           }
         }
@@ -1127,11 +1127,11 @@
                                          options, ...) {
   hasGrouping <- !is.null(grouping)
   if (hasGrouping) {
-    levels <- levels(dataset[[.v(grouping)]])
+    levels <- levels(dataset[[grouping]])
     g1 <- levels[1L]
     g2 <- levels[2L]
-    idxG1 <- dataset[[.v(grouping)]] == g1
-    idxG2 <- dataset[[.v(grouping)]] == g2
+    idxG1 <- dataset[[grouping]] == g1
+    idxG2 <- dataset[[grouping]] == g2
   } else {
     g1 <- NULL
     g2 <- NULL
@@ -1152,19 +1152,19 @@
 
         if (paired) {
           pair <- pairs[[var]]
-          group1 <- dataset[, .v(pair[[1L]])]
-          group2 <- dataset[, .v(pair[[2L]])]
+          group1 <- dataset[, pair[[1L]]]
+          group2 <- dataset[, pair[[2L]]]
           idxC <- !(is.na(group1) | is.na(group2))
           group1 <- group1[idxC]
           group2 <- group2[idxC]
         } else {
-          idxC <- !is.na(dataset[[.v(var)]])
+          idxC <- !is.na(dataset[[var]])
           if (hasGrouping) {
-            group1 <- dataset[idxG1 & idxC, .v(var)]
-            group2 <- dataset[idxG2 & idxC, .v(var)]
-            subDataSet <- dataset[idxC, .v(c(var, grouping))]
+            group1 <- dataset[idxG1 & idxC, var]
+            group2 <- dataset[idxG2 & idxC, var]
+            subDataSet <- dataset[idxC, c(var, grouping)]
           } else {
-            group1 <- dataset[idxC, .v(var)]
+            group1 <- dataset[idxC, var]
             group1 <- group1 - options$testValue
           }
         }
@@ -2286,7 +2286,7 @@
         next
       }
       groups  <- rep("1", nrow(dataset))
-      subData <- data.frame(dependent = dataset[, .v(variable)], groups = groups)
+      subData <- data.frame(dependent = dataset[, variable], groups = groups)
       p <- try(.descriptivesPlotsRainCloudFill(subData, "dependent", "groups", variable, NULL, addLines = FALSE, horiz, options$testValue))
       if(isTryError(p))
         descriptivesPlotRainCloud$setError(.extractErrorMessage(p))
@@ -2324,7 +2324,7 @@
         next
       }
       groups  <- rep(pair, each = nrow(dataset))
-      subData <- data.frame(dependent = unlist(dataset[, .v(pair)]), groups = groups)
+      subData <- data.frame(dependent = unlist(dataset[, pair]), groups = groups)
       missingIndex <- tapply(subData[["dependent"]], subData[["groups"]], is.na) # apply listwise deletion
       missingIndex <- apply(do.call(cbind, missingIndex), 1, any)
       subData <- subData[rep(!missingIndex, 2), ]

--- a/R/ttestbayesianindependentsamples.R
+++ b/R/ttestbayesianindependentsamples.R
@@ -28,7 +28,7 @@ TTestBayesianIndependentSamplesInternal <- function(jaspResults, dataset, option
 
 	# this function is the main workhorse, and also makes a table
 	grouping   <- options[["group"]]
-	levels     <- levels(dataset[[.v(grouping)]])
+	levels     <- levels(dataset[[grouping]])
 	g1 <- levels[1L]
 	g2 <- levels[2L]
 
@@ -58,9 +58,9 @@ TTestBayesianIndependentSamplesInternal <- function(jaspResults, dataset, option
   if (derivedOptions[["wilcoxTest"]])
     .ttestBayesianSetupWilcoxProgressBar(nvar, ttestState, options[["wilcoxonSamples"]])
 
-  idxg1 <- dataset[[.v(options[["group"]])]] == g1
-  idxg2 <- dataset[[.v(options[["group"]])]] == g2
-  idxNAg <- is.na(dataset[[.v(grouping)]])
+  idxg1 <- dataset[[options[["group"]]]] == g1
+  idxg2 <- dataset[[options[["group"]]]] == g2
+  idxNAg <- is.na(dataset[[grouping]])
 
   for (var in dependents[!alreadyComputed]) {
 
@@ -80,8 +80,8 @@ TTestBayesianIndependentSamplesInternal <- function(jaspResults, dataset, option
       error  <- NaN
 
       # BayesFactor package doesn't handle NAs, so it is necessary to exclude them
-      idxNA <- is.na(dataset[[.v(var)]]) | idxNAg
-      subDataSet <- dataset[!idxNA, .v(var)]
+      idxNA <- is.na(dataset[[var]]) | idxNAg
+      subDataSet <- dataset[!idxNA, var]
 
       group1 <- subDataSet[idxg1[!idxNA]]
       group2 <- subDataSet[idxg2[!idxNA]]

--- a/R/ttestbayesianonesample.R
+++ b/R/ttestbayesianonesample.R
@@ -66,7 +66,7 @@ TTestBayesianOneSampleInternal <- function(jaspResults, dataset, options, state 
       bf.raw <- NaN
       error  <- NaN
 
-      x <- dataset[[.v(var)]]
+      x <- dataset[[var]]
       x <- x[!is.na(x)]  - options[["testValue"]]
 
       if (!derivedOptions[["wilcoxTest"]]) {

--- a/R/ttestbayesianpairedsamples.R
+++ b/R/ttestbayesianpairedsamples.R
@@ -72,7 +72,7 @@ TTestBayesianPairedSamplesInternal <- function(jaspResults, dataset, options) {
         bf.raw <- NaN
         error  <- NaN
 
-        subDataSet <- dataset[, .v(c(pair[[1L]], pair[[2L]]))]
+        subDataSet <- dataset[, c(pair[[1L]], pair[[2L]])]
         subDataSet <- subDataSet[complete.cases(subDataSet), ]
 
         x <- subDataSet[[1L]]

--- a/R/ttestonesample.R
+++ b/R/ttestonesample.R
@@ -26,14 +26,14 @@ TTestOneSampleInternal <- function(jaspResults, dataset = NULL, options, ...) {
   .ttestOneSampleMainTable(  jaspResults, dataset, options, ready, type)
   .ttestOneSampleNormalTable(jaspResults, dataset, options, ready, type)
   .ttestQQPlot(              jaspResults, dataset, options, ready, type)
-  
+
   # Descriptives
   vars <- unique(unlist(options$dependent))
   .ttestDescriptivesTable(                 jaspResults, dataset, options, ready, vars)
   .ttestOneSampleDescriptivesPlot(         jaspResults, dataset, options, ready)
   .ttestOneSampleDescriptivesRainCloudPlot(jaspResults, dataset, options, ready)
   .ttestOneSampleDescriptivesBarPlot(      jaspResults, dataset, options, ready)
-  
+
 
   return()
 }
@@ -237,7 +237,7 @@ TTestOneSampleInternal <- function(jaspResults, dataset = NULL, options, ...) {
       }
       if (all(is.na(c(rowResults[["lowerCIeffectSize"]], rowResults[["lowerCIeffectSize"]]))))
         table$addFootnote(gettext("CI could not be computed for effect size, due to low sample size and/or extreme effect size."))
-      
+
       if (!(rowResults[["usedConfLevel"]] == options[["meanDifferenceCiLevel"]]))
         table$addFootnote(gettextf("Sample size too small for desired confidence level. Using %.1f%% instead", rowResults[["usedConfLevel"]]*100))
       table$addRows(row, rowNames = rowName)
@@ -250,7 +250,7 @@ TTestOneSampleInternal <- function(jaspResults, dataset = NULL, options, ...) {
                       "twoSided"  ="two.sided",
                       "greater" ="greater",
                       "less"    ="less")
-  dat <- na.omit(dataset[[ .v(variable) ]])
+  dat <- na.omit(dataset[[ variable ]])
   n   <- length(dat)
   usedConfLevel <- options[["meanDifferenceCiLevel"]]
   if (test == "Wilcoxon") {
@@ -276,7 +276,7 @@ TTestOneSampleInternal <- function(jaspResults, dataset = NULL, options, ...) {
 
     effectSizeSe <- tanh(mrSE)
     if (confIntEffSize[1] == confIntEffSize[2]) confIntEffSize <- c(NA, NA)
-    
+
   } else if (test == "Z"){
     tempResult <- .z.test("x"=dat, "alternative" = direction,
                           "mu" = options[["testValue"]], "sigma.x" = options[["zTestSd"]],
@@ -368,7 +368,7 @@ TTestOneSampleInternal <- function(jaspResults, dataset = NULL, options, ...) {
       row[["W"]] <- NaN
       table$addFootnote(errors$message, colNames = "W", rowNames = variable)
     } else {
-      data <- na.omit(dataset[[.v(variable)]])
+      data <- na.omit(dataset[[variable]])
 
       tempResult <- stats::shapiro.test(data)
       row[["W"]] <- as.numeric(tempResult[["statistic"]])
@@ -475,7 +475,7 @@ TTestOneSampleInternal <- function(jaspResults, dataset = NULL, options, ...) {
           next
       }
       groups  <- rep("1", nrow(dataset))
-      subData <- data.frame(dependent = dataset[, .v(variable)], groups = groups)
+      subData <- data.frame(dependent = dataset[, variable], groups = groups)
       p <- try(.descriptivesPlotsRainCloudFill(subData, "dependent", "groups", variable, NULL, addLines = FALSE, horiz, options$testValue))
       if(isTryError(p))
         descriptivesPlotRainCloud$setError(.extractErrorMessage(p))
@@ -491,7 +491,7 @@ TTestOneSampleInternal <- function(jaspResults, dataset = NULL, options, ...) {
     return()
   .ttestDescriptivesContainer(jaspResults, options)
   container <- jaspResults[["ttestDescriptives"]]
-  
+
   if (is.null(container[["barPlots"]])) {
     subcontainer <- createJaspContainer(gettext("Bar Plots"), dependencies = c("barPlot",
                                                                                "barPlotCiLevel",
@@ -503,7 +503,7 @@ TTestOneSampleInternal <- function(jaspResults, dataset = NULL, options, ...) {
   } else {
     subcontainer <- container[["barPlots"]]
   }
-  
+
   for (variable in options[["dependent"]]) {
     if (!is.null(subcontainer[[variable]]))
       next

--- a/R/ttestpairedsamples.R
+++ b/R/ttestpairedsamples.R
@@ -215,8 +215,8 @@ TTestPairedSamplesInternal <- function(jaspResults, dataset = NULL, options, ...
 }
 
 .ttestPairedComputeMainTableRow <- function(p1, p2, dataset, test, testStat, optionsList, options) {
-  c1 <- dataset[[ .v(p1) ]]
-  c2 <- dataset[[ .v(p2) ]]
+  c1 <- dataset[[ p1 ]]
+  c2 <- dataset[[ p2 ]]
   df <- na.omit(data.frame(c1 = c1, c2 = c2))
   c1 <- df$c1
   c2 <- df$c2
@@ -254,7 +254,7 @@ TTestPairedSamplesInternal <- function(jaspResults, dataset = NULL, options, ...
     res <- stats::t.test(c1, c2, paired = TRUE, conf.level = optionsList$percentConfidenceMeanDiff,
                          alternative = direction)
     df  <- ifelse(is.null(res$parameter), "", as.numeric(res$parameter))
-    
+
     if (options[["effectSizeCorrection"]]) {
       thisCor <- cor(c1, c2)
       d <- sqrt(2 * (1-thisCor) / n) * res[["statistic"]]
@@ -346,8 +346,8 @@ TTestPairedSamplesInternal <- function(jaspResults, dataset = NULL, options, ...
         row[["W"]] <- NaN
         table$addFootnote(errors$message, colNames = "W", rowNames = rowName)
       } else {
-        c1   <- dataset[[ .v(p1) ]]
-        c2   <- dataset[[ .v(p2) ]]
+        c1   <- dataset[[ p1 ]]
+        c2   <- dataset[[ p2 ]]
         data <- na.omit(c1 - c2)
 
         r <- stats::shapiro.test(data)
@@ -392,7 +392,7 @@ TTestPairedSamplesInternal <- function(jaspResults, dataset = NULL, options, ...
   for (var in desc.vars) {
     row <- list(v = var)
 
-    dat <- na.omit(dataset[[ .v(var) ]])
+    dat <- na.omit(dataset[[ var ]])
     n   <- as.numeric(length(dat))
     m   <- as.numeric(mean(dat, na.rm = TRUE))
     std <- as.numeric(sd(dat,   na.rm = TRUE))
@@ -423,8 +423,8 @@ TTestPairedSamplesInternal <- function(jaspResults, dataset = NULL, options, ...
   container <- jaspResults[["ttestDescriptives"]]
 
   if (is.null(container[["plots"]])) {
-    subcontainer <- createJaspContainer(gettext("Descriptives Plots"), 
-                                        dependencies = c("descriptivesPlot", 
+    subcontainer <- createJaspContainer(gettext("Descriptives Plots"),
+                                        dependencies = c("descriptivesPlot",
                                                          "descriptivesPlotCiLevel"))
     subcontainer$position <- 5
     container[["plots"]] <- subcontainer
@@ -468,7 +468,7 @@ TTestPairedSamplesInternal <- function(jaspResults, dataset = NULL, options, ...
     group = factor(c(rep(paste0(pair[[1]]), length(c1)),
                      rep(paste0(pair[[2]]), length(c2))), levels = pair)
   )
-                                 
+
   summaryStat <- .summarySEwithin(data, measurevar = "dependent", withinvars = "group",
                                  idvar = "id", conf.interval =  options[["descriptivesPlotCiLevel"]],
                                  na.rm = TRUE, .drop = FALSE)
@@ -563,7 +563,7 @@ TTestPairedSamplesInternal <- function(jaspResults, dataset = NULL, options, ...
     return()
   .ttestDescriptivesContainer(jaspResults, options)
   container <- jaspResults[["ttestDescriptives"]]
-  
+
   if (is.null(container[["plotsRainCloud"]])) {
     subcontainer <- createJaspContainer(gettext("Raincloud Plots"), dependencies = "raincloudPlot")
     subcontainer$position <- 6
@@ -571,7 +571,7 @@ TTestPairedSamplesInternal <- function(jaspResults, dataset = NULL, options, ...
   } else {
     subcontainer <- container[["plotsRainCloud"]]
   }
-  
+
   if(ready){
     errors <- .ttestBayesianGetErrorsPerVariable(dataset, options, "paired")
     for(pair in options$pairs) {
@@ -605,7 +605,7 @@ TTestPairedSamplesInternal <- function(jaspResults, dataset = NULL, options, ...
     return()
   .ttestDescriptivesContainer(jaspResults, options)
   container <- jaspResults[["ttestDescriptives"]]
-  
+
   if (is.null(container[["barPlots"]])) {
     subcontainer <- createJaspContainer(gettext("Bar Plots"), dependencies = c("barPlot",
                                                                                "barPlotCiLevel",
@@ -616,7 +616,7 @@ TTestPairedSamplesInternal <- function(jaspResults, dataset = NULL, options, ...
   } else {
     subcontainer <- container[["barPlots"]]
   }
-  
+
   for (pair in options[["pairs"]]) {
     title <- paste(pair, collapse = " - ")
     if (!is.null(subcontainer[[title]]))

--- a/inst/Description.qml
+++ b/inst/Description.qml
@@ -13,6 +13,7 @@ Description
 	license		: "GPL (>= 2)"
 	icon		: "analysis-classical-ttest.svg"
 	hasWrappers	: true
+	preloadData	: true
 
 	GroupTitle
 	{

--- a/tests/testthat/test-ttestbayesianindependentsamples.R
+++ b/tests/testthat/test-ttestbayesianindependentsamples.R
@@ -173,7 +173,7 @@ test_that("Analysis handles integer overflow", {
 
   set.seed(4491)
   dat <- data.frame(dependent_var = rnorm(2e5),
-                    grouping      = rep(c(1, 2), each = 1e5))
+                    grouping      = factor(rep(c(1, 2), each = 1e5)))
 
   options <- initTTestOptions("TTestBayesianIndependentSamples")
   options$dependent <- "dependent_var"

--- a/tests/testthat/test-verified-ttestindependentsamples.R
+++ b/tests/testthat/test-verified-ttestindependentsamples.R
@@ -8,6 +8,7 @@ context("Independent Samples TTest -- Verification project")
 options <- jaspTools::analysisOptions("TTestIndependentSamples")
 options$dependent <- "Score"
 options$group <- "Group"
+options$group.types <- "nominal"
 options$student <- TRUE
 options$welch <- TRUE
 options$mannWhitneyU <- FALSE


### PR DESCRIPTION
requires https://github.com/jasp-stats/jaspTools/pull/46 and https://github.com/jasp-stats/jaspBase/pull/157 to be merged, so right now the unit tests will fail. So probably better not to merge this.

Also removes all calls to `.v()` and `.unv()`, so to view the relevant subset of changes I would only look at the first two commits (i.e., [this](https://github.com/jasp-stats/jaspTTests/pull/272/files/d8a1e52468da3d59003efe03fff7ed055cae303e)).