### PR TITLE
Fix  "add variance errorcheck indep t-test (#301)" differently

### DIFF
--- a/R/commonTTest.R
+++ b/R/commonTTest.R
@@ -65,13 +65,11 @@ gettextf <- function(fmt, ..., domain = NULL)  {
   else if(type == "independent") {
     if (length(options$dependent) != 0 && options$group != '')
       .hasErrors(dataset,
-                 type = c('variance', 'factorLevels'),
-                 all.target = options$dependent,
+                 type = 'factorLevels',
                  factorLevels.target  = options$group,
                  factorLevels.amount  = '!= 2',
-                 variance.grouping = options$group,
                  exitAnalysisIfErrors = TRUE)
-  }
+      }
 }
 
 .ttestOptionsList <- function(options, type){

--- a/R/ttestindependentsamples.R
+++ b/R/ttestindependentsamples.R
@@ -490,8 +490,7 @@ ttestIndependentMainTableRow <- function(variable, dataset, test, testStat, effS
                          type = c('observations', 'variance', 'infinity'),
                          all.target = variable,
                          observations.amount = c('< 3', '> 5000'),
-                         all.grouping = factor,
-                         all.groupingLevel = levels)
+                         all.grouping = factor)
 
     if (!identical(errors, FALSE)) {
       row[["W"]] <- NaN

--- a/jaspTTests.Rproj
+++ b/jaspTTests.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 185a53ea-6927-459b-a179-3f05c8fa3e23
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/tests/testthat/test-ttestindependentsamples.R
+++ b/tests/testthat/test-ttestindependentsamples.R
@@ -134,6 +134,21 @@ test_that("Analysis handles errors", {
   results <- jaspTools::runAnalysis("TTestIndependentSamples", "test.csv", options)
   status <- results[["status"]]
   expect_identical(status, "validationError", label = "1-level factor check")
+
+  # per https://github.com/jasp-stats/jaspTTests/pull/301
+  # shapiro test fails gracefully
+  options$dependent <- c("drp", "g")
+  options$group <- "group"
+  options$normalityTest <- TRUE
+  results <- jaspTools::runAnalysis("TTestIndependentSamples", "Directed Reading Activities.csv", options)
+  status <- results[["status"]]
+  expect_identical(status, "complete", label = "Shapiro-Wilk fails gracefully")
+  table <- results[["results"]][["AssumptionChecks"]][["collection"]][["AssumptionChecks_ttestNormalTable"]][["data"]]
+  jaspTools::expect_equal_tables(table, list(0.973383660123721, "drp", 0.396069316406016, 1, "NaN", "g"))
+  footnote <- results[["results"]][["AssumptionChecks"]][["collection"]][["AssumptionChecks_ttestNormalTable"]]$footnotes[[2]]
+  expect_identical(footnote$cols[[1]], "W")
+  expect_identical(footnote$rows[[1]], "g")
+  expect_true(grepl("variance", footnote$text, fixed = TRUE), label = "Shapiro-Wilk has footnote when variance check fails")
 })
 
 


### PR DESCRIPTION
This PR:
- reverts commit 67a04c7
- does the variance check in the Shapiro-Wilk table itself
- adds a unit test

The root cause of the original approach was that `all.groupingLevel = levels` expects a single level per grouping variable. When the error check fails, it fails **silently** :upside_down_face:, see https://github.com/jasp-stats/jaspBase/blob/84b4c1a3dcb219151f27df36bbb69ba591589454/R/commonerrorcheck.R#L251-L253


Results after this PR:
![image](https://github.com/user-attachments/assets/2bcc5741-f887-400e-9df0-1e45eddca96a)
