### PR TITLE
[jaspTTests] Fix y-axis label editing for raincloud plots in Bayesian t-test

### DIFF
--- a/R/commonTTest.R
+++ b/R/commonTTest.R
@@ -554,8 +554,8 @@ gettextf <- function(fmt, ..., domain = NULL)  {
     ggplot2::geom_boxplot(data = pointBoxDf, mapping = ggplot2::aes(x = xb, y = y, fill = grp ), outlier.shape = NA, width = 0.2, size = 1) +
     coordFlip +
     geomHline +
-    ggplot2::scale_y_continuous(name = yLabel, breaks = yBreaks, limits = range(yBreaks)) +
-    ggplot2::scale_x_continuous(name = xLabel, breaks = xBreaks, labels = xLabels) +
+    ggplot2::scale_y_continuous(name = if(is.null(yLabel)) NULL else as.character(yLabel), breaks = yBreaks, limits = range(yBreaks)) +
+    ggplot2::scale_x_continuous(name = if(is.null(xLabel)) NULL else as.character(xLabel), breaks = xBreaks, labels = xLabels) +
     ggplot2::scale_fill_brewer(palette = rainCols) +
     ggplot2::scale_color_brewer(palette = rainCols) +
     jaspGraphs::geom_rangeframe() +


### PR DESCRIPTION
## Summary

Fixes: https://github.com/jasp-stats/INTERNAL-jasp/issues/3057

# PR Summary

## What was wrong (root cause)
When users tried to edit the y-axis title for raincloud plots in Bayesian t-test analyses, JASP threw the error "default method not implemented for type 'list'". This occurred because when JASP passes the edited title back to R, it can sometimes be passed as a list instead of a string, which caused an error in the ggplot2 scale function.

## What was changed
Modified `/R/commonTTest.R` in the `.descriptivesPlotsRainCloudFill` function:
- Line 557: Changed `name = yLabel` to `name = if(is.null(yLabel)) NULL else as.character(yLabel)` to ensure yLabel is always converted to a character string
- Line 558: Same fix for xLabel for consistency

## Why this works
The `as.character()` function will convert a list to a character string, preventing the "default method not implemented for type 'list'" error. This handles the case where JASP passes the edited title as a list when communicating with the R backend.

## Test results
All 290 tests pass after the fix.

<details>
<summary>Implementation Plan</summary>

No plan provided by agent.

</details>

<!-- OPENCLAW_ORIGINAL_TASK -->
Fix y-axis label editing for raincloud plots in Bayesian t-test


## Screenshot Analysis

### screenshot-1.png:

### Description of the Screenshot

This screenshot is from the JASP statistical software, showing a bug report related to an error encountered while editing a plot. Below is a detailed breakdown of the image:

---

#### **1. JASP Module and Analysis**
- The analysis being performed appears to involve **descriptive statistics or exploratory data analysis**.
- The plot displayed is a **combined visualization** that includes:
  - A **violin plot** (on the far right) showing the distribution of data.
  - A **boxplot** (next to the violin plot) summarizing the data.
  - A **scatterplot** (in the middle) showing individual data points.
  - A **dot plot** (at the top) showing a single data point.

#### **2. Options Selected**
- **Y-axis settings** (left panel):
  - **Show title**: Checked.
  - **Title**: "Gemiddeld Gewicht (g.)" (Dutch for "Average Weight (g.)").
  - **Show axis**: Checked.
  - **Ticks**: 
    - **Specify sequence** is selected.
    - **From**: 1000
    - **To**: 1100
    - **Steps**: 20
  - **Advanced**: No additional options are expanded.

#### **3. Output Elements**
- **Plot Title**: "Average Weight Minus the Wrapper" is displayed at the top of the plot area.
- **Y-axis Label**: "Average Weight Minus the Wrapper" is displayed on the left side of the plot.
- **Data Visualization**:
  - **Violin Plot**: Shows the density distribution of the data.
  - **Boxplot**: Summarizes the data with quartiles and outliers.
  - **Scatterplot/Dot Plot**: Displays individual data points.
    - The scatterplot is clustered around the value 1020.
    - A single dot is visible near the value 1080.

#### **4. Error Message**
- An error dialog box is prominently displayed in the center of the screen:
  - **Title**: "Error editing plot"
  - **Message**:
    ```
    Unfortunately the plot could not be edited.
    Error message:
    default method not implemented for type 'list'
    ```
  - **Additional Information**:
    - Instructions to report the issue: "If the problem persists, please report the message above at: https://jasp-stats.org/bug-reports"
  - **Buttons**: "OK" is available to dismiss the dialog.

#### **5. State of the UI**
- The plot appears to be in an editing mode, as indicated by the presence of axis settings on the left panel.
- The error suggests that an attempt to edit the plot resulted in a failure due to an internal issue in JASP.

#### **6. Observations**
- The y-axis range is set from 1000 to 1100 with 20 steps, which is reflected in the tick marks on the plot.
- The data points are concentrated around the value 1020, with one outlier at 1080.
- The violin plot and boxplot provide a summary of the distribution, indicating a relatively narrow spread of data.

---

### Transcription of the Error Message
```
Error editing plot
Unfortunately the plot could not be edited.
Error message:
default method not implemented for type 'list'
If the problem persists, please report the message above at: https://jasp-stats.org/bug-reports
```

---

### Summary
This screenshot shows a JASP interface where a user is attempting to edit a plot titled "Average Weight Minus the Wrapper." The plot combines a violin plot, boxplot, and scatterplot. An error occurs during the editing process, with the message indicating that the default method for editing plots is not implemented for the type 'list.' The error dialog provides instructions to report the issue to the JASP bug report page. The y-axis is configured to display values from 1000 to 1100 with 20 steps, and the data visualization shows a concentration of points around 1020 with an outlier at 1080. 

**Final Answer:**
\boxed{
\text{Error editing plot}
\text{Unfortunately the plot could not be edited.}
\text{Error message:}
\text{default method not implemented for type 'list'}
\text{If the problem persists, please report the message above at: https://jasp-stats.org/bug-reports}
}
<!-- /OPENCLAW_ORIGINAL_TASK -->

## Test Results

| Test Run | Result |
|----------|--------|
| **Baseline (pre-fix)** | [ FAIL 0 \| WARN 0 \| SKIP 0 \| PASS 290 ] |
| **Post-fix** | [ FAIL 0 \| WARN 0 \| SKIP 0 \| PASS 290 ] |
| **Upstream CI** | [6a8a32c](https://github.com/jasp-stats/jaspTTests/commit/6a8a32c5945fdaef23acba9bc97448ba4a2818bc) -- CI: failing |

## Automated Code Review

Approved after 1 review iteration(s).
