### PR TITLE
helpfiles: normality assumption refers to residuals, not dependent variable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,8 @@
 
 # jaspTTests (development version)
 
-
+## Changed
+* Normality assumption in the help and info text now refers to the residuals being normally distributed (matching the residual-based Q-Q plots and Shapiro-Wilk test) instead of the dependent variable, across one-sample, independent-samples, and paired-samples t-tests (frequentist and Bayesian).
 
 ---
 

--- a/inst/help/TTestBayesianIndependentSamples.md
+++ b/inst/help/TTestBayesianIndependentSamples.md
@@ -7,7 +7,7 @@ The independent samples t-test allows the user to estimate the effect size and t
 
 - Continuous dependent variable.
 - The observations in both groups are a random sample from the population.
-- The dependent variable is normally distributed in both populations.
+- The residuals are normally distributed.
 - The population variances in the two groups are homogeneous.
 
 

--- a/inst/help/TTestBayesianOneSample.md
+++ b/inst/help/TTestBayesianOneSample.md
@@ -5,7 +5,7 @@ The one sample t-test allows the user to estimate the effect size and test the n
 ### Assumptions
 - Continuous dependent variable.
 - The data are a random sample from the population.
-- The dependent variable is normally distributed in the population.
+- The residuals are normally distributed.
 
 ### Input
 ---

--- a/inst/help/TTestBayesianPairedSamples.md
+++ b/inst/help/TTestBayesianPairedSamples.md
@@ -7,7 +7,7 @@ The paired samples t-test allows you to estimate the effect size  and test the n
 ### Assumptions
 - Continuous difference score.
 - The difference scores are a random sample from the population.
-- The difference scores are normally distributed in the population.
+- The residuals (i.e., the difference scores) are normally distributed.
 
 
 ### Input

--- a/inst/help/TTestIndependentSamples.md
+++ b/inst/help/TTestIndependentSamples.md
@@ -6,7 +6,7 @@ The independent samples t-test allows the user to estimate the effect size and t
 ### Assumptions
 - The dependent variable is continuous. 
 - The observations in both groups are a random sample from the population. 
-- The dependent variable is normally distributed in both populations. 
+- The residuals are normally distributed. 
 - The population variances in the two groups are homogeneous. 
 
 ### Input

--- a/inst/help/TTestOneSample.md
+++ b/inst/help/TTestOneSample.md
@@ -6,7 +6,7 @@ The one sample t-test allows the user to estimate the effect size and test the n
 ### Assumptions
 - The dependent variable is continuous.
 - The data are a random sample from the population.
-- The dependent variable is normally distributed in the population.
+- The residuals are normally distributed.
 
 ### Input
 -------

--- a/inst/help/TTestPairedSamples.md
+++ b/inst/help/TTestPairedSamples.md
@@ -6,7 +6,7 @@ The paired samples t-test allows the user to estimate the effect size  and test 
 ### Assumptions
 - The difference score is continuous.
 - The difference scores are a random sample from the population.
-- The difference scores are normally distributed in the population.
+- The residuals (i.e., the difference scores) are normally distributed.
 
 ### Input 
 -------

--- a/inst/qml/TTestBayesianIndependentSamples.qml
+++ b/inst/qml/TTestBayesianIndependentSamples.qml
@@ -24,7 +24,7 @@ import "./common" as Common
 
 Form {
 	info: qsTr("The Bayesian independent samples t-test allows the user to estimate the effect size and test the null hypothesis that the population means of two independent groups are equal.\n") +
-	"## " + "Assumptions" + "\n" + "- Continuous dependent variable.\n" + "- The observations in both groups are a random sample from the population.\n" + "- The dependent variable is normally distributed in both populations.\n" + "- The population variances in the two groups are homogeneous."
+	"## " + "Assumptions" + "\n" + "- Continuous dependent variable.\n" + "- The observations in both groups are a random sample from the population.\n" + "- The residuals are normally distributed.\n" + "- The population variances in the two groups are homogeneous."
 
 	id: form
 	property int framework:	Common.Type.Framework.Bayesian

--- a/inst/qml/TTestBayesianOneSample.qml
+++ b/inst/qml/TTestBayesianOneSample.qml
@@ -25,7 +25,7 @@ import "./common" as Common
 Form
 {
 	info: qsTr("The one sample t-test allows you to estimate the effect size and test the null hypothesis that the population mean equals a specific constant, i.e., the test value.\n") +
-	"## " + "Assumptions" + "\n" + "- Continuous dependent variable.\n" + "- The data are a random sample from the population.\n" + "- The dependent variable is normally distributed in the population."
+	"## " + "Assumptions" + "\n" + "- Continuous dependent variable.\n" + "- The data are a random sample from the population.\n" + "- The residuals are normally distributed."
 
 	id: form
 	property int framework:	Common.Type.Framework.Bayesian

--- a/inst/qml/TTestBayesianPairedSamples.qml
+++ b/inst/qml/TTestBayesianPairedSamples.qml
@@ -24,7 +24,7 @@ import "./common" as Common
 
 Form {
 	info: qsTr("The paired samples t-test allows you to estimate the effect size and test the null hypothesis that the population mean of the difference between paired (dependent) observations equals 0.\n") +
-	"## " + "Assumptions" + "\n" + "- Continuous difference score.\n" + "- The difference scores are a random sample from the population.\n" + "- The difference scores are normally distributed in the population."
+	"## " + "Assumptions" + "\n" + "- Continuous difference score.\n" + "- The difference scores are a random sample from the population.\n" + "- The residuals (i.e., the difference scores) are normally distributed."
 	id: form
 	property int framework:	Common.Type.Framework.Bayesian
 

--- a/inst/qml/TTestIndependentSamples.qml
+++ b/inst/qml/TTestIndependentSamples.qml
@@ -28,7 +28,7 @@ Form
 		"## " + qsTr("Assumptions") + "\n" +
 		"- " + qsTr("The dependent variable is continuous.") + "\n" +
 		"- " + qsTr("The observations in both groups are a random sample from the population.") + "\n" +
-		"- " + qsTr("The dependent variable is normally distributed in each group of the independent variable.") + "\n" +
+		"- " + qsTr("The residuals are normally distributed.") + "\n" +
 		"- " + qsTr("The population variances in the two groups are homogeneous.")
 	id: form
 	property int framework:	Common.Type.Framework.Classical

--- a/inst/qml/TTestOneSample.qml
+++ b/inst/qml/TTestOneSample.qml
@@ -25,7 +25,7 @@ import "./common" as Common
 Form
 {
 	info: qsTr("The one sample t-test allows the user to estimate the effect size and test the null hypothesis that the population mean equals a specific constant, i.e., the test value.\n") + 
-    "## " + qsTr("Assumptions") + "\n" + "- The dependent variable is continuous.\n" + "- The data are a random sample from the population.\n" + "- The dependent variable is normally distributed in the population."
+    "## " + qsTr("Assumptions") + "\n" + "- The dependent variable is continuous.\n" + "- The data are a random sample from the population.\n" + "- The residuals are normally distributed."
 	id: form
 	property int framework:	Common.Type.Framework.Classical
 

--- a/inst/qml/TTestPairedSamples.qml
+++ b/inst/qml/TTestPairedSamples.qml
@@ -25,7 +25,7 @@ import "./common" as Common
 Form
 {
 	info: qsTr("The paired samples t-test allows the user to estimate the effect size and test the null hypothesis that the population mean of the difference between observations equals 0 in dependent groups.\n") +
-	"## " + qsTr("Assumptions") + "\n" + "- The difference score is continuous.\n" + "- The difference scores are a random sample from the population.\n" + "- The difference scores are normally distributed in the population."
+	"## " + qsTr("Assumptions") + "\n" + "- The difference score is continuous.\n" + "- The difference scores are a random sample from the population.\n" + "- The residuals (i.e., the difference scores) are normally distributed."
 	id: form
 	property int framework:	Common.Type.Framework.Classical
 


### PR DESCRIPTION
Align one-sample, independent, and paired t-test (freq + Bayesian) assumption text with the residual-based Q-Q plot / Shapiro-Wilk output.